### PR TITLE
Performance optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,19 @@ toml = "1.0.3"
 parking_lot = "0.12"
 spin = "0.10.0"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+
 # Developer profile: release optimizations + debug symbols. Default build target.
 # Enables the "developer" feature flag for dev-only tooling.
 # Usage: cargo build  (or explicitly: cargo build --profile developer)
 [profile.developer]
 inherits = "release"
 debug = true
+lto = "fat"
+codegen-units = 1
 
 # Profiling profile: release optimizations + full debug info for flamegraph/perf.
 # Usage: cargo build --profile profiling && perf record ./target/profiling/iris

--- a/src/hal2.rs
+++ b/src/hal2.rs
@@ -183,11 +183,12 @@ struct CodecAState {
     nonzero_seen: bool,
     stream: Option<CodecStream>,
     timer_id: Option<TimerId>,
+    audio_failed: bool,
 }
 
 impl CodecAState {
     fn new() -> Self {
-        Self { prebuf: Vec::new(), dry: 0, nonzero_seen: false, stream: None, timer_id: None }
+        Self { prebuf: Vec::new(), dry: 0, nonzero_seen: false, stream: None, timer_id: None, audio_failed: false }
     }
     fn reset_audio(&mut self) {
         self.prebuf.clear();
@@ -416,7 +417,7 @@ impl Hal2 {
                         st.nonzero_seen = true;
                     }
 
-                    if st.stream.is_none() {
+                    if st.stream.is_none() && !st.audio_failed {
                         // Prebuf phase
                         st.prebuf.push(l);
                         st.prebuf.push(r);
@@ -434,9 +435,12 @@ impl Hal2 {
                                     sample_rate: rate, stream_rate,
                                     producer: prod, resampler, _stream: stream,
                                 });
+                            } else {
+                                st.audio_failed = true;
+                                st.prebuf.clear();
                             }
                         }
-                    } else {
+                    } else if st.stream.is_some() {
                         // Active — push to ring buffer (via resampler if rates differ)
                         if let Some(cs) = st.stream.as_mut() {
                             // Rebuild stream if codec rate changed
@@ -451,7 +455,7 @@ impl Hal2 {
                 }
                 None => {
                     st.dry += 1;
-                    if st.stream.is_none() && st.dry >= DRY_LIMIT && !st.prebuf.is_empty() {
+                    if st.stream.is_none() && !st.audio_failed && st.dry >= DRY_LIMIT && !st.prebuf.is_empty() {
                         // Open stream with whatever we buffered
                         if let Some((stream, mut prod, stream_rate)) = open_output_stream(rate) {
                             let mut resampler = Resampler::new(rate, stream_rate);
@@ -464,6 +468,9 @@ impl Hal2 {
                                 sample_rate: rate, stream_rate,
                                 producer: prod, resampler, _stream: stream,
                             });
+                        } else {
+                            st.audio_failed = true;
+                            st.prebuf.clear();
                         }
                         st.dry = 0;
                     } else if st.stream.is_some() && st.dry >= DRY_LIMIT {

--- a/src/mips_core.rs
+++ b/src/mips_core.rs
@@ -326,22 +326,17 @@ impl MipsCore {
         self.interrupts.store(0, Ordering::SeqCst);
     }
 
-    /// Read a GPR by index (ensures r0 always returns 0)
-    #[inline]
+    /// Read a GPR by index. gpr[0] is always kept at zero.
+    #[inline(always)]
     pub fn read_gpr(&self, reg: u32) -> u64 {
-        if reg == 0 {
-            0
-        } else {
-            self.gpr[reg as usize]
-        }
+        unsafe { *self.gpr.get_unchecked(reg as usize) }
     }
 
-    /// Write a GPR by index (writes to r0 are ignored)
-    #[inline]
+    /// Write a GPR by index. Unconditionally re-zeros gpr[0] to avoid a branch.
+    #[inline(always)]
     pub fn write_gpr(&mut self, reg: u32, value: u64) {
-        if reg != 0 && (reg as usize) < 32 {
-            self.gpr[reg as usize] = value;
-        }
+        unsafe { *self.gpr.get_unchecked_mut(reg as usize) = value; }
+        self.gpr[0] = 0;
     }
 
     /// Update Random register based on current cycle count

--- a/src/mips_exec.rs
+++ b/src/mips_exec.rs
@@ -582,6 +582,12 @@ pub struct MipsExecutor<T: Tlb, C: MipsCache> {
     pub fpr_write_l: fn(&mut MipsCore, u32, u64),
     pub fpr_read_w:  fn(&MipsCore, u32) -> u32,
     pub fpr_write_w: fn(&mut MipsCore, u32, u32),
+    /// Local cycle counter — flushed to the shared atomic periodically to avoid
+    /// a locked bus op on every instruction.
+    local_cycles: u64,
+    /// Cached external interrupt word — reloaded every 16 instructions.
+    cached_pending: u64,
+    interrupt_check_counter: u8,
 }
 
 // ---- translate_fn wrappers (one per privilege × addressing-mode combination) ---------------
@@ -773,6 +779,9 @@ For R4000SC/MC CPUs:
             fpr_write_l: crate::mips_core::write_fpr_l_fr0,
             fpr_read_w:  crate::mips_core::read_fpr_w_fr0,
             fpr_write_w: crate::mips_core::write_fpr_w_fr0,
+            local_cycles: 0,
+            cached_pending: 0,
+            interrupt_check_counter: 0,
         };
 
         executor.rebind_atomic_ptrs();
@@ -881,12 +890,26 @@ For R4000SC/MC CPUs:
     /// step (PC, fetch, and all data memory accesses) are suppressed.
     /// It is cleared automatically after the instruction completes.
     #[inline]
-    pub fn step(&mut self) -> ExecStatus {
-        // Single atomic load: bits 8..15 = IP, bit 63 = soft-reset
-        // Safety: interrupts_ptr/cycles_ptr point into Arcs owned by core, always valid.
-        let pending = unsafe { &*self.interrupts_ptr }.load(Ordering::Relaxed);
+    /// Flush local cycle counter to the shared atomic.
+    #[inline(always)]
+    pub fn flush_cycles(&mut self) {
+        if self.local_cycles > 0 {
+            unsafe { &*self.cycles_ptr }.fetch_add(self.local_cycles, Ordering::Relaxed);
+            self.local_cycles = 0;
+        }
+    }
 
-        unsafe { &*self.cycles_ptr }.fetch_add(1, Ordering::Relaxed);
+    pub fn step(&mut self) -> ExecStatus {
+        // Increment local cycle counter (flushed to atomic by outer loop)
+        self.local_cycles += 1;
+
+        // Reload external interrupt state every 16 instructions
+        self.interrupt_check_counter = self.interrupt_check_counter.wrapping_sub(1);
+        if self.interrupt_check_counter == 0 {
+            self.interrupt_check_counter = 16;
+            self.cached_pending = unsafe { &*self.interrupts_ptr }.load(Ordering::Relaxed);
+        }
+        let pending = self.cached_pending;
 
         let pc = self.core.pc;
         #[cfg(not(feature = "lightning"))]
@@ -3091,6 +3114,8 @@ For R4000SC/MC CPUs:
     fn exec_mfc0(&mut self, d: &DecodedInstr) -> ExecStatus {
         let rt_reg = d.rt as u32;
         let rd_val = d.rd as u32;
+        // CP0 Random (reg 1) derives from cycle count — flush local counter first
+        if rd_val == 1 { self.flush_cycles(); }
         let value = self.core.read_cp0(rd_val);
         // Sign-extend 32-bit value to 64 bits
         self.core.write_gpr(rt_reg, value as u32 as i32 as i64 as u64);
@@ -3101,6 +3126,7 @@ For R4000SC/MC CPUs:
     fn exec_dmfc0(&mut self, d: &DecodedInstr) -> ExecStatus {
         let rt_reg = d.rt as u32;
         let rd_val = d.rd as u32;
+        if rd_val == 1 { self.flush_cycles(); }
         let value = self.core.read_cp0(rd_val);
         self.core.write_gpr(rt_reg, value);
         EXEC_COMPLETE
@@ -3199,6 +3225,8 @@ For R4000SC/MC CPUs:
     // Writes CP0.EntryHi, CP0.EntryLo0, CP0.EntryLo1, and CP0.PageMask to a random TLB entry
     // The random index is determined by CP0.Random register
     fn exec_tlbwr(&mut self) -> ExecStatus {
+        // Flush local cycle counter so update_random sees accurate cycle count
+        self.flush_cycles();
         self.core.update_random();
         let index = (self.core.cp0_random as usize) % self.tlb.num_entries();
         let entry = self.create_tlb_entry_from_cp0();
@@ -4244,7 +4272,16 @@ For R4000SC/MC CPUs:
         let f: Fn<T, C> = unsafe { std::mem::transmute(d.handler) };
         let status = f(self, d);
 
-        // Handle delay slot state machine
+        // Handle delay slot state machine — fast path for the common case
+        if status == EXEC_COMPLETE {
+            if self.in_delay_slot {
+                self.core.pc = self.delay_slot_target;
+                self.in_delay_slot = false;
+            } else {
+                self.core.pc = self.core.pc.wrapping_add(4);
+            }
+            return EXEC_COMPLETE;
+        }
         match status {
             EXEC_BRANCH_DELAY => {
                 if self.in_delay_slot {
@@ -4256,14 +4293,6 @@ For R4000SC/MC CPUs:
             }
             EXEC_BRANCH_LIKELY_SKIP => {
                 self.core.pc = self.core.pc.wrapping_add(8);
-            }
-            EXEC_COMPLETE => {
-                if self.in_delay_slot {
-                    self.core.pc = self.delay_slot_target;
-                    self.in_delay_slot = false;
-                    return EXEC_COMPLETE;
-                }
-                self.core.pc = self.core.pc.wrapping_add(4);
             }
             EXEC_COMPLETE_NO_INC => {
                 return EXEC_COMPLETE;
@@ -4806,6 +4835,7 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> MipsCpu<T, C> {
                 steps_since_yield += 1;
                 if steps_since_yield >= 500000 {
                     steps_since_yield = 0;
+                    exec.flush_cycles();
                     drop(exec);
                     thread::sleep(Duration::from_millis(1));
                     exec = executor.lock();
@@ -4816,6 +4846,7 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> MipsCpu<T, C> {
                     }
                 }
             }
+            exec.flush_cycles();
 
             // Print next instruction
             let next_pc = exec.core.pc;
@@ -4876,6 +4907,7 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> Device for MipsCpu<
         for _ in 0..cycles {
             exec.step();
         }
+        exec.flush_cycles();
     }
 
     fn stop(&self) {
@@ -4937,6 +4969,8 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> Device for MipsCpu<
                         _ => {}
                     }
                 }
+                // Flush local cycle counter to shared atomic once per batch
+                guard.flush_cycles();
                 // --- perf sampling (comment out to disable) ---
                 //let cycles = guard.core.cycles.load(Ordering::Relaxed);
                 //if cycles.wrapping_sub(last_cycles) >= 100_000_000 {

--- a/src/physical.rs
+++ b/src/physical.rs
@@ -610,6 +610,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).read8(addr) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             match result {
                 BusStatus::Data8(d) => println!("PHYS8 Read {:08x} -> Data8({:02x})", addr, d),
@@ -624,6 +625,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).write8(addr, val) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             println!("PHYS8 Write {:08x} val={:02x} -> {:?}", addr, val, result);
         }
@@ -635,6 +637,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).read16(addr) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             match result {
                 BusStatus::Data16(d) => println!("PHYS16 Read {:08x} -> Data16({:04x})", addr, d),
@@ -649,6 +652,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).write16(addr, val) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             println!("PHYS16 Write {:08x} val={:04x} -> {:?}", addr, val, result);
         }
@@ -660,6 +664,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).read32(addr) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             match result {
                 BusStatus::Data(d) => println!("PHYS32 Read {:08x} -> Data({:08x})", addr, d),
@@ -674,6 +679,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).write32(addr, val) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             println!("PHYS32 Write {:08x} val={:08x} -> {:?}", addr, val, result);
         }
@@ -685,6 +691,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).read64(addr) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             match result {
                 BusStatus::Data64(d) => println!("PHYS64 Read {:08x} -> Data64({:016x})", addr, d),
@@ -699,6 +706,7 @@ impl BusDevice for Physical {
         let device_ptr = self.device_map[(addr >> 16) as usize];
         let result = unsafe { (*device_ptr).write64(addr, val) };
 
+        #[cfg(not(feature = "lightning"))]
         if self.trace.load(Ordering::Relaxed) {
             println!("PHYS64 Write {:08x} val={:016x} -> {:?}", addr, val, result);
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,10 +105,10 @@ impl GlRenderer {
             // viewport_info[1] = (0, window_y_base) — bottom pixel row of this quad in window coords
             // Y flip: tex_y = (tex_height - 1) - (gl_FragCoord.y - window_y_base)
             let vs_src = "
-                #version 120
-                attribute vec2 position;
-                attribute vec2 tex_coord;
-                varying vec2 v_tex_coord;
+                #version 150
+                in vec2 position;
+                in vec2 tex_coord;
+                out vec2 v_tex_coord;
                 void main() {
                     gl_Position = vec4(position, 0.0, 1.0);
                     v_tex_coord = tex_coord;
@@ -124,9 +124,9 @@ impl GlRenderer {
             }
 
             let fs = gl.create_shader(glow::FRAGMENT_SHADER).unwrap();
-            // Try GLSL 1.30 first (texelFetch)
+            // Try GLSL 1.50 first (texelFetch, Core Profile compatible)
             gl.shader_source(fs, "
-                #version 130
+                #version 150
                 in vec2 v_tex_coord;
                 out vec4 color;
                 uniform sampler2D tex;
@@ -153,13 +153,14 @@ impl GlRenderer {
             }
 
             if !linked {
-                // Fallback to GLSL 1.20 (UV-based, no texelFetch)
+                // Fallback (UV-based, no texelFetch)
                 gl.shader_source(fs, "
-                    #version 120
-                    varying vec2 v_tex_coord;
+                    #version 150
+                    in vec2 v_tex_coord;
+                    out vec4 color;
                     uniform sampler2D tex;
                     void main() {
-                        gl_FragColor = texture2D(tex, v_tex_coord);
+                        color = texture(tex, v_tex_coord);
                     }
                 ");
                 gl.compile_shader(fs);


### PR DESCRIPTION
I'm now seeing ~91 MIPS on a M2 Mac Mini.

-----

 
  Phase 1: Build profile tuning (Cargo.toml)                                                                             
   
  - Added lto = "fat" — enables cross-crate inlining, critical for devirtualizing BusDevice trait calls on the hot path  
  - Added codegen-units = 1 — lets LLVM optimize the entire crate as one unit
  - Added panic = "abort" — eliminates unwinding tables, improves icache density                                         
  - Applied to both [profile.release] and [profile.developer]                                                            
                                                                                                                         
  Phase 2: Batch cycle counter (mips_exec.rs)                                                                            
                                                            
  - Replaced per-instruction atomic fetch_add(1) with a local u64 counter                                                
  - Flushed to the shared atomic once per 10K-instruction batch in the outer loop
  - Added targeted flushes before TLBWR and MFC0/DMFC0 $Random which need an accurate cycle count for TLB random index   computation                                                                                                            
                                                                                                                         
  Phase 3: Batch interrupt check (mips_exec.rs)                                                                          
                                                            
  - Replaced per-instruction atomic load of external interrupt state with a cached value                                 
  - Reloaded from the atomic every 16 instructions instead of every instruction
  - The CP0 timer interrupt (IP7) is computed locally so it's unaffected                                                 
                                                                                                                         
  Phase 4: Compile out trace checks (physical.rs)                                                                        
                                                                                                                         
  - Wrapped all 8 trace.load(Ordering::Relaxed) blocks in #[cfg(not(feature = "lightning"))]                             
  - Eliminates an atomic load on every physical bus read/write in lightning builds
                                                                                                                         
  Phase 5: Fast-path delay slot match (mips_exec.rs)        
                                                                                                                         
  - Pulled EXEC_COMPLETE (the ~80% common case) out of the 7-arm match in exec_decoded() into a leading if check         
  - Non-branch instructions skip the match entirely
                                                                                                                         
  Phase 6: GPR r0 elimination (mips_core.rs)                                                                             
  
  - read_gpr: removed the if reg == 0 branch, replaced with get_unchecked (gpr[0] is always kept at zero)                
  - write_gpr: removed the if reg != 0 branch and bounds check, replaced with unconditional write + gpr[0] = 0
                                                                                                                         
  Bug fixes (pre-existing + regression)                     
                                                                                                                         
  - GLSL shaders (ui.rs): Updated from #version 120/130 to #version 150 with Core Profile syntax — macOS only supports   
  OpenGL 3.2+ Core Profile
  - Audio spam (hal2.rs): Added audio_failed flag so open_output_stream failure only prints once instead of spamming on  
  every timer tick                                                                                                       
  - TLB random regression (mips_exec.rs): Cycle counter batching starved update_random() — fixed by flushing local cycles  before TLBWR and MFC0/DMFC0 for register 1    