### PR TITLE
test: drop irix_install_scsi_disk_present (fixes CI failure)

### DIFF
--- a/src/platform_profile_tests.rs
+++ b/src/platform_profile_tests.rs
@@ -1,8 +1,8 @@
 //! Headless acceptance tests for IP22/IP24 profile wiring, XZ, and IMPACT stubs.
 //!
-//! These run in `cargo test --lib` without booting the guest. When
-//! `irix-install/scsi1.raw` is present, use `iris-indigo2-smoke-ci.toml` for
-//! live boot checks (monitor on 127.0.0.1:8888; CI serial is channel B / IRIX).
+//! These run in `cargo test --lib` without booting the guest. For live boot
+//! checks, point `iris-indigo2-smoke-ci.toml` at a local IRIX root disk (raw or
+//! CHD; monitor on 127.0.0.1:8888; CI serial is channel B / IRIX).
 
 #[cfg(test)]
 mod tests {
@@ -23,15 +23,6 @@ mod tests {
         let mut cfg = MachineConfig::default();
         cfg.scsi.clear();
         cfg
-    }
-
-    #[test]
-    fn irix_install_scsi_disk_present() {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/irix-install/scsi1.raw");
-        assert!(
-            std::path::Path::new(path).exists(),
-            "irix-install/scsi1.raw — IRIX root disk for smoke/CI configs"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`main` CI currently fails on the `Run tests` step:

```
test platform_profile_tests::tests::irix_install_scsi_disk_present ... FAILED
test result: FAILED. 294 passed; 1 failed
```

The test asserts that `irix-install/scsi1.raw` exists on disk:

```rust
let path = concat!(env!("CARGO_MANIFEST_DIR"), "/irix-install/scsi1.raw");
assert!(std::path::Path::new(path).exists(), ...);
```

But that root image is **gitignored** and is never present on a CI runner or a fresh clone, so the test fails on every build. It also isn't a real invariant: a root disk can be supplied as either a raw image **or** a CHD, so requiring the specific `.raw` path is wrong.

## Fix

The test exercises no emulator behavior — it only checks for a local artifact — so this removes it and updates the module doc comment to note the smoke config takes a raw or CHD disk. The remaining 15 profile tests still pass.

Introduced in f2d0bff (Indigo2 IP22 platform); unrelated to any single feature PR, it just surfaces on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)