### PR TITLE
snapshot: re-anchor the mc timebase on start

### DIFF
--- a/src/mc.rs
+++ b/src/mc.rs
@@ -1251,6 +1251,10 @@ impl Device for MemoryController {
 
     fn start(&self) {
         if self.running.swap(true, Ordering::SeqCst) { return; }
+        // A stale anchor makes the first update_timers bill the guest for the
+        // pause. Catches every mc.stop()/start() pair; a CPU-only pause is
+        // still billed, since it never stops the MC.
+        self.state.lock().last_host_ticks = crate::platform::get_host_ticks();
         let mc = self.clone();
         self.threads.lock().push(thread::Builder::new().name("MC-DMA".to_string()).spawn(move || {
             mc.dma_worker();
@@ -1542,6 +1546,26 @@ mod tests {
         let v2 = dst.save_state();
 
         assert_eq!(v1, v2, "MemoryController save_state mismatch after load_state round-trip");
+    }
+
+    /// Fails at 1.5e9 counts without the re-anchor in `start()`.
+    #[test]
+    fn start_reanchors_timebase() {
+        let eeprom = Arc::new(Mutex::new(Eeprom93c56::new()));
+        let mc = MemoryController::new(eeprom, true, [0u32; 4]);
+
+        let freq = crate::platform::get_host_tick_frequency();
+        mc.state.lock().last_host_ticks =
+            crate::platform::get_host_ticks().wrapping_sub(freq * 100);
+
+        mc.start();
+        let rpss = mc.read32(MC_BASE + REG_RPSS_CTR).data;
+        mc.stop();
+
+        // The 100 s stale interval is 1.5e9 counts at 50 MHz through DIV=10
+        // INC=3. 15e6 is one second at that same rate.
+        assert!(rpss < 15_000_000,
+            "RPSS_CTR advanced {rpss} counts across a stopped interval");
     }
 
     #[test]


### PR DESCRIPTION
##### Changes
- Re-anchor `last_host_ticks` in `MemoryController::start()`, after the `running.swap` guard so a redundant start does not discard live elapsed time.
- Not in `load_state`: `machine.rs:1448` runs it well before the bulk memory restore at `1503-1526`, and `restart_peripherals()` is the last statement of `load_snapshot_inner`.
- `cpu_cycle_acc` and `rpss_cycle_acc` are left alone; `power_on` already zeroes them and runs first on every restore path.

##### Coverage / needs eyes
- `mc::tests::start_reanchors_timebase` stales the anchor by 100 s, calls `start()`, reads `REG_RPSS_CTR`. Reverting the one-line fix fails it at `1500000954` counts, the predicted 1.5e9 for 100 s at 50 MHz. With the fix the same read lands at 777-831 counts over four runs.
- `cargo test --release --features lightning,rex-jit,chd`: 358 passed, 11 ignored.
- Found via one `update_timers` step of `cpu_cycles=16630691385` after a snapshot restore, `RPSS_CTR` `0x24d1b19` to `0xc88ead47`.
- Does not cover a CPU-only pause. `gdb_stub.rs:726/810` and the monitor `cpu stop` command stop the CPU without stopping the MC, so `start()` never runs and a held breakpoint is still billed on the next MC read. Worth a follow-up, left out to keep this to one thing.
