### PR TITLE
iris-gui: port live MIPS estimate to CyclesPtr

### DIFF
--- a/iris-gui/src/handle.rs
+++ b/iris-gui/src/handle.rs
@@ -314,7 +314,7 @@ fn worker_loop(
     // the delta by wall-clock between ticks. Mirrors the status-bar math in
     // src/disp.rs, but driven here since the GUI never runs REX3's own
     // refresh/status-bar loop. `None` until a machine is up.
-    let mut cycles: Option<std::sync::Arc<std::sync::atomic::AtomicU64>> = None;
+    let mut cycles: Option<iris::mips_core::CyclesPtr> = None;
     let mut prev_cycles: u64 = 0;
     let mut prev_tick = std::time::Instant::now();
     // Tick cadence for the status poll while idle on the command channel.
@@ -323,11 +323,11 @@ fn worker_loop(
         match cmd_rx.recv_timeout(STATUS_TICK) {
             // Periodic tick (no command pending): refresh the MIPS estimate.
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                if let Some(c) = &cycles {
+                if let Some(c) = cycles {
                     let now = std::time::Instant::now();
                     let dt = now.duration_since(prev_tick).as_secs_f64();
                     if dt >= 0.1 {
-                        let cur = c.load(std::sync::atomic::Ordering::Relaxed);
+                        let cur = c.get();
                         let dc = cur.wrapping_sub(prev_cycles);
                         let mips = (dc as f64 / dt / 1_000_000.0 * 10.0).round() as f32 / 10.0;
                         prev_cycles = cur;
@@ -406,11 +406,8 @@ fn worker_loop(
                                 .into_iter().map(|h| (h.network, h.prefix)).collect());
                         *ps2_slot.lock() = Some(m.get_ps2());
                         // Latch REX3's cycle counter for the live MIPS estimate.
-                        cycles = m.get_rex3().map(|r| r.cycles.clone());
-                        prev_cycles = cycles
-                            .as_ref()
-                            .map(|c| c.load(std::sync::atomic::Ordering::Relaxed))
-                            .unwrap_or(0);
+                        cycles = m.get_rex3().map(|r| r.cycles.get());
+                        prev_cycles = cycles.map(|c| c.get()).unwrap_or(0);
                         prev_tick = std::time::Instant::now();
                         machine = Some(m);
                         let _ = evt_tx.send(Evt::Started);


### PR DESCRIPTION
## Problem

`iris-gui` doesn't compile on current `main`:

```
error[E0308]: mismatched types
   --> iris-gui/src/handle.rs:409:34
    |
409 |                         cycles = m.get_rex3().map(|r| r.cycles.clone());
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<Arc<Atomic<u64>>>`, found `Option<Cell<CyclesPtr>>`
error: could not compile `iris-gui` (bin "iris-gui") due to 1 previous error
```

926d56f ("convert cycles atomic into regular volatile variable") changed `Rex3::cycles` from `Arc<AtomicU64>` to `Cell<CyclesPtr>` across 11 files under `src/`, but `iris-gui/` wasn't updated. The GUI's worker loop uses that counter for its live MIPS estimate, so it was still calling `.clone()` on the `Arc` and `.load(Ordering::Relaxed)` to read it.

The CLI (`iris`, `iris-ci`) builds fine — only the GUI is affected.

## Fix

Latch the `CyclesPtr` by value rather than cloning an `Arc`, and read it with `.get()`:

```rust
let mut cycles: Option<iris::mips_core::CyclesPtr> = None;
...
cycles = m.get_rex3().map(|r| r.cycles.get());
prev_cycles = cycles.map(|c| c.get()).unwrap_or(0);
```

This mirrors REX3's own refresh thread at `src/rex3.rs:3863` (`self.cycles.get().get()` — `Cell::get` for the pointer, then `CyclesPtr::get` for the count).

Notes on correctness:

- `CyclesPtr` is `Copy`/`Send`/`Sync` and its doc comment names cross-thread status displays as the intended consumer, valid for the process lifetime. The GUI's MIPS readout is exactly that — it exists because the GUI never runs REX3's own refresh/status-bar loop.
- Being `Copy`, the `Option` no longer needs `.as_ref()`.
- `.get()` is null-safe (returns 0 while dangling), and the pointer is already wired up by the time the GUI latches it, since that happens after `Machine::new` returns.
- The existing `Stop`/`SyncDisks` paths already reset `cycles = None` before the machine is dropped, so no dangling read.

## Testing

`./build.sh` on macOS arm64 (rustc 1.99.0-nightly), CLI features `lightning,rex-jit,tlbvmap,idle-pause` and GUI features `iris/lightning,iris/idle-pause`: all three binaries build clean. No new warnings.