### PR TITLE
dedupe glow/spin, fix disk-image bugs, add ci chd-sync, bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,10 @@ path = "src/bin/chd_extract.rs"
 required-features = ["chd"]
 
 [[bin]]
+name = "mkvh"
+path = "src/bin/mkvh.rs"
+
+[[bin]]
 name = "jitv2_analyze"
 path = "src/bin/jitv2_analyze.rs"
 required-features = ["jitv2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,9 @@ env_logger = "0.11"
 winit = "0.30"
 glutin = "0.32"
 glutin-winit = "0.5"
-glow = "0.13"
+glow = "0.17"
 raw-window-handle = "0.6"
-rtrb = "0.3"
+rtrb = "0.4"
 socket2 = { version = "0.6", features = ["all"] }
 crossbeam-utils = "0.8"
 crossbeam-queue = "0.3"
@@ -161,7 +161,7 @@ postcard = { version = "1", features = ["alloc"] }
 blake3 = "1"
 png = "0.18"
 parking_lot = "0.12"
-spin = "0.12"
+spin = "0.9"
 # rfd >= 0.16 dropped the async-std/tokio runtime features: `xdg-portal` now
 # pulls its own `pollster` executor to block on the portal's async D-Bus calls.
 rfd = { version = "0.17", default-features = false, features = ["xdg-portal"] }
@@ -260,6 +260,11 @@ required-features = ["jitv2"]
 # is dead-stripped. See rules/macos/appstore-private-api.md.
 [patch.crates-io]
 winit = { path = "third_party/winit-0.30.13" }
+# block 0.1.6 is that crate's final release (2016) and declares a static of an
+# uninhabited type, a future hard error (rust#74840). Reached only on macOS, via
+# nokhwa -> cocoa/metal. The vendored copy makes `Class` opaque-but-inhabited, as
+# its maintained successor block2 does. Drop when nokhwa stops pulling `block`.
+block = { path = "third_party/block-0.1.6" }
 
 
 

--- a/docs/cpu-test-support.md
+++ b/docs/cpu-test-support.md
@@ -1,0 +1,100 @@
+# Emulator support for bare-metal CPU tests
+
+Four additive, default-off features for running a self-checking bare-metal MIPS
+binary under IRIS. None of them changes an ordinary IRIX boot.
+
+## A — `mkvh`: bootable volume headers
+
+`src/sgi_vh.rs` gained the volume directory (0x048, 15 × 16 bytes), so an image
+can carry named standalone files the PROM boots by name.
+
+```sh
+mkvh build boot.img --size 16M sashARCS=./sashARCS      # bootable by name
+mkvh build boot.img --size 64M --part 7:5:+:2048=efs.img cputest=./cputest
+mkvh dump /path/to/sgi.iso                              # parse real media
+```
+
+`--part slot:type:first:nblks[=file]`; `first` may be `+`, meaning "start where
+the volume header ends", which is what SGI's own media does. **An EFS filesystem
+partition is type 5 (`PT_SYSV`)**, not 7 — see
+`rules/testing/sgi-volume-directory-layout-verified-on-real-media.md`.
+
+From the PROM: `boot -f dksc(0,<scsi-id>,8)<name>`.
+
+## B — `--load-elf` / monitor `loadelf`
+
+Load a static ELF32 MSB `ET_EXEC` for `EM_MIPS` straight into RAM and jump to
+its entry point — no image to rebuild between edits.
+
+```sh
+iris --load-elf ./cputest.elf          # cold start, no PROM involved
+```
+```
+> cpu stop
+> loadelf ./cputest.elf                # segments + entry are printed
+> loadbin ./blob.bin 0x88300000        # raw bytes, PC untouched
+> run
+```
+
+Loading requires a stopped CPU — that is what keeps the JIT honest, since its
+block cache is owned by the dispatch loop and dies with the CPU thread. The
+loaded range is flushed out of L1D/L2 and invalidated out of L1I, so reloading a
+different binary at the same address runs the new code.
+
+Link at **0x88000000+** (Indy RAM starts at physical 0x08000000). Before POST no
+RAM is mapped at all; `--load-elf` maps the banks the way POST does, and every
+load probes the bus first and refuses rather than writing into the void. See
+`rules/testing/loading-code-before-post-ram-is-unmapped.md`.
+
+## C — TFTP for PROM network boot
+
+```sh
+iris --tftp-dir ./build     # or [network] tftp_dir = "./build"
+```
+```
+>> boot -f bootp()cputest
+```
+
+Read-only RFC 1350 inside the NAT gateway (no host socket, no new entitlement).
+RRQ only, octet only, 512-byte ACK-driven blocks, bounded retransmits, and paths
+that escape the root — `..`, absolute, or via symlink — are refused. Unset means
+no TFTP at all.
+
+## D — test device (`--test-device`)
+
+MMIO at `0x1F400000` (GIO expansion slot 0, empty on a stock Indy), 64 KB, four
+word registers repeating every 16 bytes:
+
+| Offset | Access | Behaviour |
+|---|---|---|
+| `0x00` | read | `SIGNATURE` = `0x49524953` (`"IRIS"`). Absent on real hardware, so the suite falls back to SCC-only output. |
+| `0x04` | write | `PUTC` — low byte to the host's stdout. |
+| `0x08` | write | `DUMP` — full machine state to JSON; the written value tags the dump point. |
+| `0x0C` | write | `EXIT` — terminate the emulator with the written value as the process exit code. |
+
+```sh
+iris --test-device --test-device-dump ./dump.json --load-elf ./cputest.elf
+```
+
+The dump carries `gpr[32]`, `hi`/`lo`, `pc`, the CP0 registers by name,
+`fpr[32]` plus FCSR/FIR, and identifies R4400 vs R5000 from PRId.
+
+`--cheritest-dump-hook` additionally makes a guest write to **CP0 register 26**
+trigger the same dump, the convention the external `cheritest` corpus uses. It
+is off by default and must stay that way for a normal boot: CP0 26 is ECC on a
+real R4400 and the PROM writes it during cache initialisation.
+
+## Getting results back
+
+Exit code for the verdict, stdout for the log, the dump for diagnosis:
+
+| Channel | Carries | Host side |
+|---|---|---|
+| `EXIT` | pass/fail | process exit code — no string matching, works headless |
+| `PUTC` | per-test lines | stdout |
+| `DUMP` | state at a failure | JSON, diffable between runs |
+| SCC ttyd1 | the same lines on real hardware | `--serial-log FILE` |
+
+Prefer `--serial-log` over scraping TCP 8881: the serial backend holds one
+client and only notices a dead one on a failed write
+(`rules/testing/scc-serial-output-from-bare-metal-code.md`).

--- a/iris-gui/Cargo.toml
+++ b/iris-gui/Cargo.toml
@@ -101,8 +101,8 @@ ultra64 = ["iris/ultra64"]
 # opt-in passthrough features (above), since neither is usable without extra
 # setup — IRIS_JIT=1 for the one, an external gopher64 for the other.
 iris = { path = "..", features = ["chd", "camera", "rex-jit"] }
-eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
-egui = "0.35"
+eframe = { version = "0.36", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }
+egui = "0.36"
 crossbeam-channel = "0.5"
 parking_lot = "0.12"
 # Match iris's winit version — Ps2Controller::push_kb takes

--- a/iris-gui/src/config_ui.rs
+++ b/iris-gui/src/config_ui.rs
@@ -559,7 +559,7 @@ fn show_disks(ui: &mut Ui, cfg: &mut MachineConfig) -> (PathEdit, ConfigAction) 
                 }
             } else if ui.button("Attach…").clicked() {
                 cfg.scsi.insert(id, ScsiDeviceConfig {
-                    path: format!("scsi{id}.raw"),
+                    path: crate::settings::GuiSettings::default_disk_path(id),
                     ..Default::default()
                 });
             }
@@ -1017,6 +1017,20 @@ fn show_network(
             .clicked()
         {
             add = Some(PortForwardConfig { proto: ForwardProto::Tcp, host_port: 2121, guest_port: 21, bind: ForwardBind::Localhost });
+            ui.close();
+        }
+        if ui.add_enabled(!has_port(22), egui::Button::new("SSH (host 2222 to guest 22)"))
+            .on_hover_text("Log in with: ssh -p 2222 user@localhost. IRIX ships no sshd — install OpenSSH in the guest first.")
+            .clicked()
+        {
+            add = Some(PortForwardConfig { proto: ForwardProto::Tcp, host_port: 2222, guest_port: 22, bind: ForwardBind::Localhost });
+            ui.close();
+        }
+        if ui.add_enabled(!has_port(5900), egui::Button::new("VNC (host 5901 to guest 5900)"))
+            .on_hover_text("Reach a VNC server on the guest's display :0. Host side is 5901 because macOS Screen Sharing already owns 5900.")
+            .clicked()
+        {
+            add = Some(PortForwardConfig { proto: ForwardProto::Tcp, host_port: 5901, guest_port: 5900, bind: ForwardBind::Localhost });
             ui.close();
         }
         if ui.add_enabled(!has_port(177), egui::Button::new("XDMCP (host 11177 to guest 177, UDP)"))
@@ -1683,18 +1697,13 @@ fn path_row(
             out.changed |= ui.add(TextEdit::singleline(value).desired_width(320.0)).changed();
             if ui.button("📁").on_hover_text("Browse…").clicked() {
                 let mut d = rfd::FileDialog::new();
-                // Start the dialog in the existing path's directory if any.
-                if !value.is_empty() {
-                    let p = Path::new(value);
-                    if let Some(parent) = p.parent() {
-                        if parent.as_os_str().len() > 0 && parent.exists() {
-                            d = d.set_directory(parent);
-                        }
-                    }
-                    if let Some(name) = p.file_name() {
-                        d = d.set_file_name(name.to_string_lossy());
-                    }
-                }
+                // Start in the existing path's folder, else the managed disks dir.
+                let p = Path::new(value.as_str());
+                let dir = p.parent().filter(|d| !d.as_os_str().is_empty() && d.is_dir())
+                    .map(|d| d.to_path_buf())
+                    .or_else(|| crate::settings::GuiSettings::disks_dir().filter(|d| d.is_dir()));
+                if let Some(dir) = dir { d = d.set_directory(dir); }
+                if let Some(name) = p.file_name() { d = d.set_file_name(name.to_string_lossy()); }
                 if matches!(mode, Pick::OpenFile | Pick::SaveFile) {
                     for (label, exts) in filters {
                         d = d.add_filter(*label, exts);

--- a/iris-gui/src/dialogs/create_disk.rs
+++ b/iris-gui/src/dialogs/create_disk.rs
@@ -7,6 +7,7 @@ pub struct CreateDiskDialog {
     scsi_id: u8,
     filename: String,
     size_mb: f64,
+    overwrite: bool,
     result: Option<CreateDiskResult>,
 }
 
@@ -17,7 +18,7 @@ pub struct CreateDiskResult {
 
 impl Default for CreateDiskDialog {
     fn default() -> Self {
-        Self { open: false, scsi_id: 1, filename: String::new(), size_mb: 1024.0, result: None }
+        Self { open: false, scsi_id: 1, filename: String::new(), size_mb: 1024.0, overwrite: false, result: None }
     }
 }
 
@@ -28,6 +29,7 @@ impl CreateDiskDialog {
         // sandbox too) so a new disk never lands in the working dir.
         self.filename = crate::settings::GuiSettings::default_disk_path(scsi_id);
         self.size_mb = 1024.0;
+        self.overwrite = false;
         self.result = None;
         self.open = true;
     }
@@ -70,10 +72,24 @@ impl CreateDiskDialog {
                 ui.label(RichText::new("The image will be created as a zero-filled file. \
                     Reset the machine after attaching new drives.")
                     .color(Color32::GRAY).small());
+                // File::create truncates: without this gate, Create silently wipes an
+                // existing image (the default filename is the disk already at this ID).
+                let exists = std::path::Path::new(&self.filename).is_file();
+                if exists {
+                    let mb = std::fs::metadata(&self.filename).map(|m| m.len()).unwrap_or(0) as f64
+                        / (1024.0 * 1024.0);
+                    ui.add_space(4.0);
+                    ui.label(RichText::new(format!(
+                        "⚠ {} already exists ({mb:.0} MB). Creating will erase it.", self.filename))
+                        .color(Color32::from_rgb(230, 140, 70)));
+                    ui.checkbox(&mut self.overwrite, "Erase the existing image");
+                } else {
+                    self.overwrite = false;
+                }
                 ui.add_space(6.0);
                 ui.horizontal(|ui| {
                     if ui.button("Cancel").clicked() { close = true; }
-                    if ui.add(egui::Button::new("Create")
+                    if ui.add_enabled(!exists || self.overwrite, egui::Button::new("Create")
                         .fill(Color32::from_rgb(60, 110, 60))).clicked()
                     {
                         // Create file on disk now (making the parent dir first,

--- a/iris-gui/src/handle.rs
+++ b/iris-gui/src/handle.rs
@@ -464,6 +464,7 @@ fn worker_loop(
                     cycles = None;
                     m.stop();
                     synced = match m.sync_chd_disks(
+                        None,
                         &mut |disk, total, fraction| {
                             let _ = evt_tx.send(Evt::SyncProgress { disk, total, fraction });
                         },

--- a/iris-gui/src/main.rs
+++ b/iris-gui/src/main.rs
@@ -3107,7 +3107,8 @@ impl eframe::App for App {
                     .map(|(id, _)| *id);
 
                 if let Some(id) = cdrom_id {
-                    if let Some(path) = scsi_menu::pick_iso("Load CD-ROM disc") {
+                    let cur = self.cfg.scsi.get(&id).map(|d| d.path.clone()).unwrap_or_default();
+                    if let Some(path) = scsi_menu::pick_iso("Load CD-ROM disc", &cur) {
                         self.emu.send(Cmd::LoadDisc { id, path, remount: true });
                     }
                 } else {

--- a/iris-gui/src/scsi_menu.rs
+++ b/iris-gui/src/scsi_menu.rs
@@ -29,7 +29,7 @@ pub fn draw(ui: &mut Ui, cfg: &MachineConfig) -> ScsiAction {
             match dev {
                 None => {
                     if ui.button("Attach HDD…").clicked() {
-                        if let Some(p) = pick_disk("Attach HDD") {
+                        if let Some(p) = pick_disk("Attach HDD", "") {
                             action = ScsiAction::AttachHdd { id, path: p };
                         }
                         ui.close();
@@ -42,7 +42,7 @@ pub fn draw(ui: &mut Ui, cfg: &MachineConfig) -> ScsiAction {
                         ui.close();
                     }
                     if ui.button("Attach CD-ROM with disc…").clicked() {
-                        if let Some(p) = pick_iso("Attach CD-ROM with disc") {
+                        if let Some(p) = pick_iso("Attach CD-ROM with disc", "") {
                             action = ScsiAction::AttachCdromWithDisc { id, path: p };
                         }
                         ui.close();
@@ -71,7 +71,7 @@ pub fn draw(ui: &mut Ui, cfg: &MachineConfig) -> ScsiAction {
                     }
                     let insert_label = if has_media { "Swap disc…" } else { "Insert disc…" };
                     if ui.button(insert_label).clicked() {
-                        if let Some(p) = pick_iso("Insert disc") {
+                        if let Some(p) = pick_iso("Insert disc", &d.path) {
                             action = ScsiAction::InsertDisc { id, path: p };
                         }
                         ui.close();
@@ -100,7 +100,7 @@ pub fn draw(ui: &mut Ui, cfg: &MachineConfig) -> ScsiAction {
                         ui.close();
                     }
                     if ui.button("Replace image…").clicked() {
-                        if let Some(p) = pick_disk("Replace HDD image") {
+                        if let Some(p) = pick_disk("Replace HDD image", &d.path) {
                             action = ScsiAction::AttachHdd { id, path: p };
                         }
                         ui.close();
@@ -154,18 +154,32 @@ fn render_label(id: u8, dev: Option<&ScsiDeviceConfig>) -> String {
     }
 }
 
-fn pick_disk(title: &str) -> Option<String> {
-    rfd::FileDialog::new()
-        .set_title(title)
+// Seed the picker at `cur`'s folder, else the managed disks dir — never the OS default.
+fn dialog_at(title: &str, cur: &str) -> rfd::FileDialog {
+    let mut d = rfd::FileDialog::new().set_title(title);
+    let p = Path::new(cur);
+    match p.parent().filter(|d| !d.as_os_str().is_empty() && d.is_dir()) {
+        Some(dir) => {
+            d = d.set_directory(dir);
+            if let Some(n) = p.file_name() { d = d.set_file_name(n.to_string_lossy()); }
+        }
+        None => if let Some(dir) = crate::settings::GuiSettings::disks_dir().filter(|d| d.is_dir()) {
+            d = d.set_directory(dir);
+        }
+    }
+    d
+}
+
+fn pick_disk(title: &str, cur: &str) -> Option<String> {
+    dialog_at(title, cur)
         .add_filter("Disk images", &["raw", "img", "chd"])
         .add_filter("All", &["*"])
         .pick_file()
         .map(|p| p.to_string_lossy().into_owned())
 }
 
-pub fn pick_iso(title: &str) -> Option<String> {
-    rfd::FileDialog::new()
-        .set_title(title)
+pub fn pick_iso(title: &str, cur: &str) -> Option<String> {
+    dialog_at(title, cur)
         .add_filter("ISO images", &["iso", "chd"])
         .add_filter("All", &["*"])
         .pick_file()

--- a/rules/snapshot/per-device-saveloadsave-round-trip-is-the-regression-net.md
+++ b/rules/snapshot/per-device-saveloadsave-round-trip-is-the-regression-net.md
@@ -37,7 +37,8 @@ fn save_load_round_trip() {
 
 ## What's covered
 
-eeprom_93c56, ds1x86, ioc, pit8254, mc, mips_tlb, ps2, z85c30, wd33c93a, seeq8003.
+eeprom_93c56, ds1x86, ioc, pit8254, mc, mips_tlb, ps2, z85c30, wd33c93a, seeq8003,
+testdev.
 
 ## What's not (yet) covered
 

--- a/rules/testing/loading-code-before-post-ram-is-unmapped.md
+++ b/rules/testing/loading-code-before-post-ram-is-unmapped.md
@@ -1,0 +1,33 @@
+# Loading code before POST: RAM is unmapped, and the write is silent
+
+`MEMCFG0/1` are **zero at reset** (`mc.rs`: "all banks invalid at reset (VLD=0
+per spec)"), so on a cold machine *no RAM is mapped anywhere*. The PROM
+configures the banks during POST. Anything that writes to RAM before that —
+`--load-elf`, a scripted `mw`, a test harness poking memory — is writing into
+the void.
+
+Two things make that failure completely silent, and both have to be handled:
+
+1. **`UnmappedRam` accepts every write and reads back 0** (`mem.rs`), and
+   `Physical` routes unmapped lomem/himem slots to it. No bus error, no status
+   code — `debug_write` returns `EXEC_COMPLETE`. The only symptom is a
+   `MC: CPU Error at <phys>` line on stderr, which nothing checks.
+2. **A cached probe cannot detect it.** KSEG0 is cacheable, so a
+   write-then-read-back through `debug_write`/`debug_read` is absorbed by L1D
+   and returns the pattern you just wrote even with nothing behind it. Probe on
+   the bus (`exec.sysad.read32`/`write32` at the *translated* physical address)
+   and restore the original word.
+
+`load_range()` in `mips_exec.rs` probes both ends of every range that way before
+committing an image, and `Machine::load_elf` calls `MemoryController::post_map_banks()`
+first, which programs MEMCFG0 exactly as POST does (bank 0 at `LOMEM_BASE`,
+bank 1 at `LOMEM_BASE + BANK_SIZE`; banks 2/3 are synthesised at HIMEM by the
+MEMCFG write itself). That is what makes a cold-start `--load-elf` land in real
+RAM with no PROM involved.
+
+Related: **Indy RAM starts at physical 0x08000000**, not 0. A bare-metal binary
+therefore links at **0x88000000+** (KSEG0), not 0x80000000 — physical 0 is a
+512 KB alias window (`ALIAS_BASE`..`ALIAS_END`) that mirrors the *bottom* of
+lomem and nothing else, so an image at 0x80100000 lands nowhere.
+And KSEG1 for a device at physical `0x1FBD9830` is `0xBFBD9830` — KSEG1 masks
+the top three bits, so `0xA1BD9830` silently becomes physical `0x01BD9830`.

--- a/rules/testing/scc-serial-output-from-bare-metal-code.md
+++ b/rules/testing/scc-serial-output-from-bare-metal-code.md
@@ -1,0 +1,27 @@
+# Getting serial output out of bare-metal guest code
+
+Three things silently swallow SCC output, all hit while bringing up the CPU
+test-suite support. In order of how long each one costs you:
+
+1. **IOC serial 1 is SCC channel *B*, not A.** `IOC_SERIAL1_CMD`/`_DATA`
+   (`0x1FBD9830`/`0x34`) map to `Z85c30::write` indices 0/1, and that function
+   dispatches `0 => channel B, 2 => channel A`. So the first serial port in the
+   IOC map is ttyd1 → **TCP 8881**. Channel A (ttyd2, TCP 8880) is at
+   `0x1FBD9838`/`0x3C`. Writing to `0x…30` and listening on 8880 gets you
+   nothing, and looks exactly like a broken device.
+
+2. **Transmit is gated on WR5.TX_ENABLE.** An uninitialised channel queues the
+   byte and the TX thread never latches it. Minimum init for output: write `5`
+   to the command register (select WR5), then `0x68` (`TX_8BITS | TX_ENABLE`).
+   Baud/BRG can stay unset — `tx_delay` then works out to 4 µs per character.
+
+3. **The TCP serial backend holds exactly one client, and only notices a dead
+   one on a failed write.** `TcpSocketBackend::send_byte` writes to
+   `conn` if it is `Some`; `conn` is only replaced by an `accept()` inside
+   `recv_byte`, which runs when `guard.is_none()`. A client that connected and
+   went away leaves `conn` populated, so a *new* connection sits unaccepted in
+   the backlog and every transmitted byte is written into the dead socket.
+   Symptom: you connect, get no telnet handshake (`ff fb 01 …`), and see no
+   output. Treat "no handshake within a second" as "reconnect", or use
+   `--serial-log FILE`, which tees ttyd1 to a file and avoids the socket
+   entirely — much the better option for a CI harness.

--- a/rules/testing/sgi-volume-directory-layout-verified-on-real-media.md
+++ b/rules/testing/sgi-volume-directory-layout-verified-on-real-media.md
@@ -1,0 +1,40 @@
+# SGI volume directory: layout verified against real media
+
+`struct volume_header`'s volume directory sits at **0x048**, 15 entries of 16
+bytes: `char vd_name[8]; int vd_lbn; int vd_nbytes;` — big-endian, `vd_lbn` in
+512-byte blocks from the start of the *volume*, `vd_nbytes` the exact byte
+length. This was confirmed by parsing media IRIX itself wrote, not by
+round-tripping our own writer (`mkvh dump`, Feature A):
+
+- An installed IRIX 6.5 system disk (`Indy-IRIX65_dev.chd`, sector 0):
+
+  ```
+  bootfile  "/unix"          checksum valid
+    ide      lbn        2      343040 bytes
+    sash     lbn      672      343040 bytes
+    slot  0  first 266240  nblks 8122368  type 10 (PT_XFS)
+    slot  1  first   4096  nblks  262144  type  3 (PT_RAW)
+    slot  8  first      0  nblks    4096  type  0 (PT_VOLHDR)
+    slot 10  first      0  nblks 8388608  type  6 (PT_VOLUME)
+  ```
+
+  Both files start with `0x0163` (SGI ECOFF, MIPSEB) at exactly `lbn * 512`,
+  and `ide` ends (1024 + 343040 = 344064) precisely where `sash` begins
+  (672 * 512) — contiguous, so the field offsets can't be coincidence.
+
+- IRIX 6.5.22 / nekoware / mkisofs-built CDs parse with a **valid checksum and
+  an empty voldir**. Data CDs are not bootable-by-name; do not read an empty
+  voldir as a parse failure. Only media prepared with `dvhtool` (or an SGI
+  installer) carries entries.
+
+Gotchas:
+
+- An 8-character name fills `vd_name` with **no NUL terminator** — parse the
+  8 bytes and trim, never `strlen`. `sashARCS` is exactly 8.
+- A used slot is detected by `vd_name[0] != 0`; entries need not be contiguous.
+- The checksum (0x1F8) covers all 128 big-endian words and must sum to zero, so
+  it has to be recomputed after *every* mutation, voldir writes included.
+- The volume-header partition (slot 8) must be large enough to contain the
+  files the voldir points at — the real disk above uses 4096 blocks for
+  ~672 KB of `sash`/`ide`, not the 8-block minimum `create_scratch_image()`
+  writes for the scratch volume.

--- a/rules/testing/sgi-volume-directory-layout-verified-on-real-media.md
+++ b/rules/testing/sgi-volume-directory-layout-verified-on-real-media.md
@@ -22,10 +22,24 @@ round-tripping our own writer (`mkvh dump`, Feature A):
   and `ide` ends (1024 + 343040 = 344064) precisely where `sash` begins
   (672 * 512) — contiguous, so the field offsets can't be coincidence.
 
-- IRIX 6.5.22 / nekoware / mkisofs-built CDs parse with a **valid checksum and
-  an empty voldir**. Data CDs are not bootable-by-name; do not read an empty
-  voldir as a parse failure. Only media prepared with `dvhtool` (or an SGI
-  installer) carries entries.
+- The IRIX 6.5.22 *Installation Tools and Overlays (1 of 3)* CD — the reference
+  for the writer, reproduced exactly by `mkvh dump`:
+
+  ```
+  magic 0x0BE5A941  rootpt 0  swappt 0  bootfile ''   csum VALID
+    sgilabel lbn      32          512 bytes
+    mr       lbn      33     19200000 bytes      (the miniroot)
+    sash64   lbn   37533       266000 bytes
+    sashARCS lbn   38053       342532 bytes      (what an Indy boots)
+    slot  7  first  48736  nblks 1283016  type 5 (PT_SYSV)
+    slot  8  first      0  nblks   48736  type 0 (PT_VOLHDR)
+    slot 10  first      0  nblks 1331776  type 6 (PT_VOLUME)
+  ```
+
+- Data CDs (nekoware, mkisofs-built, the "full" 6.5.22 image) parse with a
+  **valid checksum and an empty voldir**. They are not bootable-by-name; an
+  empty voldir is not a parse failure. Only media prepared with `dvhtool` or an
+  SGI installer carries entries.
 
 Gotchas:
 
@@ -34,7 +48,19 @@ Gotchas:
 - A used slot is detected by `vd_name[0] != 0`; entries need not be contiguous.
 - The checksum (0x1F8) covers all 128 big-endian words and must sum to zero, so
   it has to be recomputed after *every* mutation, voldir writes included.
-- The volume-header partition (slot 8) must be large enough to contain the
-  files the voldir points at — the real disk above uses 4096 blocks for
-  ~672 KB of `sash`/`ide`, not the 8-block minimum `create_scratch_image()`
-  writes for the scratch volume.
+- The volume-header partition (slot 8) must **span every file the voldir points
+  at**. The install CD gives it 48736 blocks (~24 MB) for sash/miniroot and the
+  installed disk 4096 blocks for ~672 KB of `sash`/`ide` — not the 8-block
+  minimum `create_scratch_image()` writes for a file-less scratch volume. The
+  filesystem partition then starts exactly where it ends (block 48736 on the
+  CD), which is what `PartitionSpec { first_block: None }` emits.
+- **An EFS filesystem partition is type 5 (`PT_SYSV`), not type 7 (`PT_EFS`).**
+  Counter-intuitive, but it is what shipping SGI media emits: partition 7 of the
+  install CD is type 5, and the EFS superblock is really there — block 1 of that
+  partition has `fs_magic = 0x00072959` at offset 0x1c with `fs_size = 1280320`.
+  Emit what the CD emits, not what the type name suggests.
+- Both PROM loader paths appear on that one CD: `sashARCS` is ECOFF
+  (`f_magic 0x0163` MIPSEBMAGIC, OMAGIC, `F_EXEC`, text at 0x10000000, entry
+  0x10021020) and `sash64` is an ELF64 MSB `ET_REL` object the PROM relocates
+  (the PROM's "Cannot load and relocate %s." string). 0x10000000 is therefore a
+  load address this PROM demonstrably accepts.

--- a/src/bin/mkvh.rs
+++ b/src/bin/mkvh.rs
@@ -1,0 +1,172 @@
+//! SGI volume-header image tool: build a PROM-bootable image, or dump one.
+//!
+//! Build:  mkvh build <out.img> [--size N] [--bootfile NAME]
+//!                    [--part slot:type:first:nblks[=file]] <name=path> ...
+//! Dump:   mkvh dump <image>
+//!
+//! A built image is bootable by name from the PROM:
+//!   boot -f dksc(0,<scsi-id>,8)<name>
+//!
+//! Dump mode is the layout check: run it on an original SGI CD and the voldir
+//! should list sashARCS and friends with a valid checksum.
+
+use std::path::PathBuf;
+use std::process::exit;
+
+use iris::sgi_vh::{build_image, ImageSpec, PartitionSpec, VolumeHeader};
+
+const USAGE: &str = "\
+usage:
+  mkvh build <out.img> [options] <name=path> [name=path ...]
+  mkvh dump  <image>
+
+build options:
+  --size N          image size in bytes (K/M/G suffix allowed); default: fit contents
+  --bootfile NAME   vh_bootfile; default: the first file
+  --part SPEC       partition entry, repeatable:
+                    slot:type:first:nblks[=file]  (decimal, or 0x-prefixed)
+                    e.g. --part 7:4:1024:2048=efs.img  (type 4 = PT_EFS)
+";
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let r = match args.get(1).map(String::as_str) {
+        Some("build") => build(&args[2..]),
+        Some("dump") => dump(&args[2..]),
+        _ => { eprint!("{}", USAGE); exit(2); }
+    };
+    if let Err(e) = r {
+        eprintln!("mkvh: {}", e);
+        exit(1);
+    }
+}
+
+fn build(args: &[String]) -> Result<(), String> {
+    let mut out: Option<PathBuf> = None;
+    let mut spec = ImageSpec::default();
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        match a.as_str() {
+            "--size" => { spec.total_bytes = parse_size(next(args, &mut i, "--size")?)?; }
+            "--bootfile" => { spec.bootfile = Some(next(args, &mut i, "--bootfile")?.to_string()); }
+            "--part" => { spec.partitions.push(parse_part(next(args, &mut i, "--part")?)?); }
+            _ if a.starts_with("--") => return Err(format!("unknown option '{}'\n{}", a, USAGE)),
+            _ if out.is_none() => out = Some(PathBuf::from(a)),
+            _ => {
+                let (name, path) = a.split_once('=')
+                    .ok_or_else(|| format!("file argument '{}' is not name=path", a))?;
+                spec.files.push((name.to_string(), PathBuf::from(path)));
+            }
+        }
+        i += 1;
+    }
+    let out = out.ok_or_else(|| format!("no output path given\n{}", USAGE))?;
+    if spec.files.is_empty() && spec.partitions.is_empty() {
+        return Err(format!("nothing to write\n{}", USAGE));
+    }
+
+    let placed = build_image(&out, &spec).map_err(|e| e.to_string())?;
+    let size = std::fs::metadata(&out).map(|m| m.len()).unwrap_or(0);
+    println!("wrote {} ({} bytes)", out.display(), size);
+    for f in &placed {
+        println!("  {:<8} lbn {:>8}  {:>10} bytes", f.name, f.lbn, f.nbytes);
+    }
+    Ok(())
+}
+
+fn dump(args: &[String]) -> Result<(), String> {
+    let path = args.first().ok_or_else(|| format!("no image given\n{}", USAGE))?;
+    let mut buf = vec![0u8; 512];
+    {
+        use std::io::Read;
+        let mut f = std::fs::File::open(path).map_err(|e| format!("{}: {}", path, e))?;
+        f.read_exact(&mut buf).map_err(|e| format!("{}: {}", path, e))?;
+    }
+    let vh = VolumeHeader::from_bytes(&buf).map_err(|e| format!("{}: {}", path, e))?;
+
+    println!("{}:", path);
+    println!("  magic     0x0BE5A941 (ok)");
+    println!("  bootfile  {:?}", vh.bootfile());
+    println!("  checksum  {}", if vh.csum_valid() { "valid" } else { "INVALID" });
+
+    let files = vh.files();
+    println!("  volume directory ({} of 15 entries):", files.len());
+    for f in &files {
+        println!("    {:<8} lbn {:>8}  {:>10} bytes", f.name, f.lbn, f.nbytes);
+    }
+
+    println!("  partition table:");
+    for p in vh.partitions() {
+        println!(
+            "    slot {:>2}  first {:>10}  nblks {:>10}  type {:>2} ({})",
+            p.slot, p.first_block, p.nblks, p.ptype, ptype_name(p.ptype)
+        );
+    }
+    if !vh.csum_valid() {
+        return Err("checksum does not validate".to_string());
+    }
+    Ok(())
+}
+
+fn next<'a>(args: &'a [String], i: &mut usize, what: &str) -> Result<&'a str, String> {
+    *i += 1;
+    args.get(*i).map(String::as_str).ok_or_else(|| format!("{} needs an argument", what))
+}
+
+fn parse_num(s: &str) -> Result<u64, String> {
+    let t = s.trim();
+    let r = match t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
+        Some(hex) => u64::from_str_radix(hex, 16),
+        None => t.parse::<u64>(),
+    };
+    r.map_err(|_| format!("'{}' is not a number", s))
+}
+
+fn parse_size(s: &str) -> Result<u64, String> {
+    let (num, mult) = match s.chars().last() {
+        Some('K') | Some('k') => (&s[..s.len() - 1], 1024),
+        Some('M') | Some('m') => (&s[..s.len() - 1], 1024 * 1024),
+        Some('G') | Some('g') => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        _ => (s, 1),
+    };
+    Ok(parse_num(num)? * mult)
+}
+
+fn parse_part(s: &str) -> Result<PartitionSpec, String> {
+    let (fields, content) = match s.split_once('=') {
+        Some((f, p)) => (f, Some(PathBuf::from(p))),
+        None => (s, None),
+    };
+    let v: Vec<&str> = fields.split(':').collect();
+    if v.len() != 4 {
+        return Err(format!("--part '{}' must be slot:type:first:nblks[=file]", s));
+    }
+    Ok(PartitionSpec {
+        slot: parse_num(v[0])? as usize,
+        ptype: parse_num(v[1])? as u32,
+        first_block: parse_num(v[2])? as u32,
+        nblks: parse_num(v[3])? as u32,
+        content,
+    })
+}
+
+fn ptype_name(t: u32) -> &'static str {
+    match t {
+        0 => "PT_VOLHDR",
+        1 => "PT_TRKREPL",
+        2 => "PT_SECREPL",
+        3 => "PT_RAW",
+        4 => "PT_BSD",
+        5 => "PT_SYSV",
+        6 => "PT_VOLUME",
+        7 => "PT_EFS",
+        8 => "PT_LVOL",
+        9 => "PT_RLVOL",
+        10 => "PT_XFS",
+        11 => "PT_XFSLOG",
+        12 => "PT_XLV",
+        13 => "PT_XVM",
+        _ => "?",
+    }
+}

--- a/src/bin/mkvh.rs
+++ b/src/bin/mkvh.rs
@@ -25,7 +25,10 @@ build options:
   --bootfile NAME   vh_bootfile; default: the first file
   --part SPEC       partition entry, repeatable:
                     slot:type:first:nblks[=file]  (decimal, or 0x-prefixed)
-                    e.g. --part 7:4:1024:2048=efs.img  (type 4 = PT_EFS)
+                    first may be `+` = start right after the volume header
+                    e.g. --part 7:5:+:1283016=efs.img
+                    NB: SGI ships an EFS filesystem as type 5 (PT_SYSV), not
+                    type 7 — that is what the 6.5.22 install CD emits.
 ";
 
 fn main() {
@@ -87,6 +90,8 @@ fn dump(args: &[String]) -> Result<(), String> {
 
     println!("{}:", path);
     println!("  magic     0x0BE5A941 (ok)");
+    let (rootpt, swappt) = vh.root_swap_parts();
+    println!("  rootpt    {}   swappt {}", rootpt, swappt);
     println!("  bootfile  {:?}", vh.bootfile());
     println!("  checksum  {}", if vh.csum_valid() { "valid" } else { "INVALID" });
 
@@ -142,10 +147,14 @@ fn parse_part(s: &str) -> Result<PartitionSpec, String> {
     if v.len() != 4 {
         return Err(format!("--part '{}' must be slot:type:first:nblks[=file]", s));
     }
+    let first_block = match v[2] {
+        "+" | "auto" => None,
+        n => Some(parse_num(n)? as u32),
+    };
     Ok(PartitionSpec {
         slot: parse_num(v[0])? as usize,
         ptype: parse_num(v[1])? as u32,
-        first_block: parse_num(v[2])? as u32,
+        first_block,
         nblks: parse_num(v[3])? as u32,
         content,
     })
@@ -158,7 +167,7 @@ fn ptype_name(t: u32) -> &'static str {
         2 => "PT_SECREPL",
         3 => "PT_RAW",
         4 => "PT_BSD",
-        5 => "PT_SYSV",
+        5 => "PT_SYSV", // what SGI media uses for an EFS filesystem
         6 => "PT_VOLUME",
         7 => "PT_EFS",
         8 => "PT_LVOL",

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -252,7 +252,7 @@ fn handle_client_tcp(server: Arc<CiServer>, stream: TcpStream) {
 fn dispatch(server: &CiServer, req: &Request) -> Response {
     match req.cmd.as_str() {
         "ping" => Response::ok(),
-        "quit" => cmd_quit(),
+        "quit" => cmd_quit(server, &req.args),
         "start" => cmd_start(server),
         "save" => cmd_save(server, &req.args),
         "restore" => cmd_restore(server, &req.args),
@@ -277,6 +277,7 @@ fn dispatch(server: &CiServer, req: &Request) -> Response {
         "rtc-save"      => cmd_rtc_save(server, &req.args),
         "cdrom-eject"   => cmd_cdrom_eject(server, &req.args),
         "cdrom-load"    => cmd_cdrom_load(server, &req.args),
+        "chd-sync"      => cmd_chd_sync(server, &req.args),
         other => Response::err(format!("unknown command: {}", other)),
     }
 }
@@ -326,7 +327,53 @@ fn cmd_cdrom_load(server: &CiServer, args: &Value) -> Response {
     }
 }
 
-fn cmd_quit() -> Response {
+/// Parse a SCSI target selector: absent, null or "all" mean every disk.
+fn scsi_selector(v: Option<&Value>) -> Result<Option<usize>, String> {
+    match v {
+        None | Some(Value::Null) => Ok(None),
+        Some(v) if v.as_str() == Some("all") => Ok(None),
+        Some(v) => match v.as_u64() {
+            Some(n) if n < 8 => Ok(Some(n as usize)),
+            _ => Err(format!("bad scsi id {v} (expected 0-7 or \"all\")")),
+        },
+    }
+}
+
+/// Fold pending CHD diffs into their bases. The guest must be stopped: folding
+/// releases the disk backend, so a running IRIX would lose the drive mid-flight.
+fn cmd_chd_sync(server: &CiServer, args: &Value) -> Response {
+    let only = match scsi_selector(args.get("id")) {
+        Ok(v) => v,
+        Err(e) => return Response::err(e),
+    };
+    if server.with_machine(|m| m.cpu_is_running()) {
+        return Response::err("CPU is running — stop the guest first \
+                              (folding releases the disk backend)");
+    }
+    match server.with_machine(|m| m.sync_chd_disks(only, &mut |_, _, _| {}, &|| false)) {
+        Ok(n) => Response::data(serde_json::json!({ "synced": n })),
+        Err(e) => Response::err(e.to_string()),
+    }
+}
+
+fn cmd_quit(server: &CiServer, args: &Value) -> Response {
+    // `sync_chd` present => fold before exiting. Stop the machine first so the
+    // fold is quiesced, mirroring the GUI's "Synchronizing disks…" exit step.
+    let mut synced = serde_json::Value::Null;
+    if args.get("sync_chd").is_some() {
+        let only = match scsi_selector(args.get("sync_chd")) {
+            Ok(v) => v,
+            Err(e) => return Response::err(e),
+        };
+        let r = server.with_machine(|m| {
+            m.stop();
+            m.sync_chd_disks(only, &mut |_, _, _| {}, &|| false)
+        });
+        match r {
+            Ok(n) => synced = serde_json::json!(n),
+            Err(e) => return Response::err(format!("chd sync failed: {e}")),
+        }
+    }
     // Schedule process exit after a brief delay so the response flushes.
     thread::spawn(|| {
         thread::sleep(Duration::from_millis(50));
@@ -340,7 +387,7 @@ fn cmd_quit() -> Response {
             std::process::exit(0);
         }
     });
-    Response::ok()
+    Response::data(serde_json::json!({ "synced": synced }))
 }
 
 fn cmd_start(server: &CiServer) -> Response {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -95,7 +95,7 @@ impl SwCompositor {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::RGBA as i32,
-                2048, 1024, 0, glow::RGBA, glow::UNSIGNED_BYTE, None);
+                2048, 1024, 0, glow::RGBA, glow::UNSIGNED_BYTE, glow::PixelUnpackData::Slice(None));
             t
         };
         self.tex = Some(t);
@@ -259,7 +259,7 @@ impl Compositor for SwCompositor {
                 glow::TEXTURE_2D, 0,
                 0, 0, width as i32, height as i32,
                 glow::RGBA, glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(u8_slice),
+                glow::PixelUnpackData::Slice(Some(u8_slice)),
             );
             gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -804,6 +804,11 @@ pub struct MachineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gdb_port: Option<u16>,
 
+    /// If Some(path), load this static ELF32 MSB binary into RAM at startup and
+    /// set PC to its entry point (bare-metal test binaries; see --load-elf).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub load_elf: Option<String>,
+
     /// NAT subnet in CIDR notation (e.g. "192.168.5.0/24").
     /// The gateway gets host .1 and the guest (IRIX) gets host .2.
     /// Defaults to "192.168.0.0/24" if not set.
@@ -992,6 +997,7 @@ impl Default for MachineConfig {
             headless: false,
             no_audio: false,
             gdb_port: None,
+            load_elf: None,
             nat_subnet: None,
             ci: false,
             ci_socket: default_ci_socket(),
@@ -1331,6 +1337,12 @@ pub struct Cli {
     #[arg(long = "gdb-port", value_name = "PORT")]
     pub gdb_port: Option<u16>,
 
+    /// Load a static ELF32 MSB (big-endian MIPS) binary into RAM before the
+    /// CPU starts and set PC to its entry point, instead of booting the PROM.
+    /// For bare-metal test binaries; see also the monitor's `loadelf`.
+    #[arg(long = "load-elf", value_name = "FILE")]
+    pub load_elf: Option<String>,
+
     /// CI mode: enable the control socket and apply speed-favoring fidelity
     /// shortcuts. Implies --headless unless --ci-display is also set.
     #[arg(long, default_value_t = false)]
@@ -1416,6 +1428,7 @@ impl Cli {
         }
 
         if let Some(p) = self.gdb_port { cfg.gdb_port = Some(p); }
+        if let Some(ref p) = self.load_elf { cfg.load_elf = Some(p.clone()); }
         if let Some(ref s) = self.nat_subnet { cfg.nat_subnet = Some(s.clone()); }
 
         if let Some(m) = self.net_mode { cfg.network.mode = m; }

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,6 +274,9 @@ pub struct NetworkConfig {
     /// (Indy) / serial EEPROM (Indigo2) before boot. Defaults to
     /// [`DEFAULT_MAC`] when `[network] mac` is unset.
     pub mac: [u8; 6],
+    /// Directory served read-only over TFTP at the gateway, for PROM network
+    /// boot. None (the default) disables the TFTP server.
+    pub tftp_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for NetworkConfig {
@@ -285,6 +288,7 @@ impl Default for NetworkConfig {
             mode: NetMode::default(),
             pcap_interface: None,
             nfs_pcap_ip: None,
+            tftp_dir: None,
             mac: DEFAULT_MAC,
         }
     }
@@ -318,6 +322,10 @@ pub struct NetworkSection {
     /// from the PROM monitor and saved with `rtc save`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mac: Option<String>,
+    /// Directory served read-only over TFTP (UDP 69) at the gateway address, so
+    /// the PROM can `boot -f bootp()<file>`. Unset disables TFTP.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tftp_dir: Option<String>,
 }
 
 /// Where VINO's video-in capture should come from.
@@ -809,6 +817,23 @@ pub struct MachineConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub load_elf: Option<String>,
 
+    /// Map the bare-metal test device (guest console, machine-state dump, exit
+    /// code) into GIO expansion slot 0. Off by default; see src/testdev.rs.
+    #[serde(default)]
+    pub test_device: bool,
+
+    /// Where the test device's DUMP register writes its JSON. Defaults to
+    /// `iris-testdev-dump.json` in the working directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_device_dump: Option<String>,
+
+    /// cheritest convention: a guest write to CP0 register 26 triggers the same
+    /// dump as the test device's DUMP register. Off by default and must stay
+    /// that way for a normal boot — CP0 26 is ECC on a real R4400 and the PROM
+    /// writes it during cache initialisation.
+    #[serde(default)]
+    pub cheritest_dump_hook: bool,
+
     /// NAT subnet in CIDR notation (e.g. "192.168.5.0/24").
     /// The gateway gets host .1 and the guest (IRIX) gets host .2.
     /// Defaults to "192.168.0.0/24" if not set.
@@ -998,6 +1023,9 @@ impl Default for MachineConfig {
             no_audio: false,
             gdb_port: None,
             load_elf: None,
+            test_device: false,
+            test_device_dump: None,
+            cheritest_dump_hook: false,
             nat_subnet: None,
             ci: false,
             ci_socket: default_ci_socket(),
@@ -1190,6 +1218,7 @@ impl MachineConfig {
             pcap_interface: self.network.pcap_interface.clone(),
             nfs_pcap_ip:  self.network.nfs_pcap_ip,
             mac,
+            tftp_dir:     self.network.tftp_dir.as_ref().map(std::path::PathBuf::from),
         }
     }
 
@@ -1337,6 +1366,27 @@ pub struct Cli {
     #[arg(long = "gdb-port", value_name = "PORT")]
     pub gdb_port: Option<u16>,
 
+    /// Map the bare-metal test device into GIO expansion slot 0: SIGNATURE,
+    /// PUTC (guest console → stdout), DUMP (machine state → JSON) and EXIT
+    /// (terminate with the guest's exit code). Off by default.
+    #[arg(long = "test-device", default_value_t = false)]
+    pub test_device: bool,
+
+    /// Where the test device writes its machine-state dump.
+    #[arg(long = "test-device-dump", value_name = "FILE")]
+    pub test_device_dump: Option<String>,
+
+    /// cheritest convention: a guest write to CP0 register 26 dumps machine
+    /// state. Needs --test-device. Never enable for a normal boot — CP0 26 is
+    /// ECC on a real R4400 and the PROM writes it during cache init.
+    #[arg(long = "cheritest-dump-hook", default_value_t = false)]
+    pub cheritest_dump_hook: bool,
+
+    /// Serve this directory read-only over TFTP at the gateway address, so the
+    /// PROM can network-boot from it: `boot -f bootp()<file>`. Off when unset.
+    #[arg(long = "tftp-dir", value_name = "DIR")]
+    pub tftp_dir: Option<String>,
+
     /// Load a static ELF32 MSB (big-endian MIPS) binary into RAM before the
     /// CPU starts and set PC to its entry point, instead of booting the PROM.
     /// For bare-metal test binaries; see also the monitor's `loadelf`.
@@ -1429,6 +1479,10 @@ impl Cli {
 
         if let Some(p) = self.gdb_port { cfg.gdb_port = Some(p); }
         if let Some(ref p) = self.load_elf { cfg.load_elf = Some(p.clone()); }
+        if let Some(ref d) = self.tftp_dir { cfg.network.tftp_dir = Some(d.clone()); }
+        if self.test_device { cfg.test_device = true; }
+        if let Some(ref p) = self.test_device_dump { cfg.test_device_dump = Some(p.clone()); }
+        if self.cheritest_dump_hook { cfg.cheritest_dump_hook = true; }
         if let Some(ref s) = self.nat_subnet { cfg.nat_subnet = Some(s.clone()); }
 
         if let Some(m) = self.net_mode { cfg.network.mode = m; }

--- a/src/debug_overlay.rs
+++ b/src/debug_overlay.rs
@@ -397,7 +397,7 @@ impl DebugOverlay {
                 glow::TEXTURE_2D, 0,
                 0, 0, src.width as i32, src.height as i32,
                 glow::RGBA, glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(u8_slice),
+                glow::PixelUnpackData::Slice(Some(u8_slice)),
             );
             gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
         }
@@ -418,7 +418,7 @@ impl DebugOverlay {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::RGBA as i32,
-                2048, 1024, 0, glow::RGBA, glow::UNSIGNED_BYTE, None);
+                2048, 1024, 0, glow::RGBA, glow::UNSIGNED_BYTE, glow::PixelUnpackData::Slice(None));
             t
         };
         self.tex = Some(t);

--- a/src/disp.rs
+++ b/src/disp.rs
@@ -437,7 +437,7 @@ impl StatusBarTexture {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::RGBA as i32,
-                2048, STATUS_BAR_HEIGHT as i32, 0, glow::RGBA, glow::UNSIGNED_BYTE, None);
+                2048, STATUS_BAR_HEIGHT as i32, 0, glow::RGBA, glow::UNSIGNED_BYTE, glow::PixelUnpackData::Slice(None));
             t
         };
         self.tex = Some(t);
@@ -460,7 +460,7 @@ impl StatusBarTexture {
                 glow::TEXTURE_2D, 0,
                 0, 0, width as i32, STATUS_BAR_HEIGHT as i32,
                 glow::RGBA, glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(u8_slice),
+                glow::PixelUnpackData::Slice(Some(u8_slice)),
             );
             gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
         }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,0 +1,172 @@
+//! Static ELF32 MSB reader for the monitor's `loadelf` and `--load-elf`.
+//!
+//! Only what a bare-metal MIPS test binary needs: the program headers and the
+//! entry point. Byte-swapping here is correct — file parsing is "The Edge".
+
+/// A `PT_LOAD` segment: `data` is `p_filesz` bytes to copy to `vaddr`, then
+/// zero-fill out to `memsz`.
+#[derive(Debug)]
+pub struct Segment {
+    pub vaddr: u64,
+    pub memsz: u64,
+    pub flags: u32,
+    pub offset: usize,
+    pub filesz: usize,
+}
+
+#[derive(Debug)]
+pub struct Elf32 {
+    pub entry: u64,
+    pub segments: Vec<Segment>,
+}
+
+const PT_LOAD: u32 = 1;
+const PT_DYNAMIC: u32 = 2;
+const PT_INTERP: u32 = 3;
+
+/// `rwx` for a segment's `p_flags`.
+pub fn flag_str(flags: u32) -> String {
+    let bit = |m: u32, c: char| if flags & m != 0 { c } else { '-' };
+    [bit(4, 'r'), bit(2, 'w'), bit(1, 'x')].iter().collect()
+}
+
+/// Parse a static ELF32 MSB `ET_EXEC` for `EM_MIPS`. Anything else is rejected
+/// by name rather than half-loaded.
+pub fn parse(bytes: &[u8]) -> Result<Elf32, String> {
+    if bytes.len() < 52 {
+        return Err(format!("too short to be an ELF file ({} bytes)", bytes.len()));
+    }
+    if &bytes[0..4] != b"\x7fELF" {
+        return Err("not an ELF file (bad magic)".to_string());
+    }
+    match bytes[4] {
+        1 => {}
+        2 => return Err("ELF64 is not supported — build a 32-bit (-melf32btsmip) binary".to_string()),
+        c => return Err(format!("unknown ELF class {}", c)),
+    }
+    if bytes[5] != 2 {
+        return Err("little-endian ELF — MIPS/IRIX binaries must be big-endian (MSB)".to_string());
+    }
+
+    let be16 = |o: usize| u16::from_be_bytes([bytes[o], bytes[o + 1]]);
+    let be32 = |o: usize| u32::from_be_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]);
+
+    match be16(16) {
+        2 => {}
+        3 => return Err("ET_DYN (shared/PIE) — link statically as ET_EXEC".to_string()),
+        t => return Err(format!("not an executable (e_type {})", t)),
+    }
+    if be16(18) != 8 {
+        return Err(format!("not a MIPS binary (e_machine {})", be16(18)));
+    }
+
+    // 32-bit MIPS addresses are sign-extended, so KSEG0 works in both 32- and
+    // 64-bit addressing modes.
+    let sext = |v: u32| v as i32 as i64 as u64;
+
+    let phoff = be32(28) as usize;
+    let phentsize = be16(42) as usize;
+    let phnum = be16(44) as usize;
+    if phnum == 0 {
+        return Err("no program headers — nothing to load".to_string());
+    }
+    if phentsize < 32 || phoff + phnum * phentsize > bytes.len() {
+        return Err("program header table is out of bounds".to_string());
+    }
+
+    let mut segments = Vec::new();
+    for i in 0..phnum {
+        let p = phoff + i * phentsize;
+        let ptype = be32(p);
+        if ptype == PT_DYNAMIC || ptype == PT_INTERP {
+            return Err("dynamically linked — link statically (-static)".to_string());
+        }
+        if ptype != PT_LOAD {
+            continue;
+        }
+        let offset = be32(p + 4) as usize;
+        let filesz = be32(p + 16) as usize;
+        let memsz = be32(p + 20) as u64;
+        if offset + filesz > bytes.len() {
+            return Err(format!("segment {} runs past the end of the file", i));
+        }
+        if (filesz as u64) > memsz {
+            return Err(format!("segment {} has p_filesz > p_memsz", i));
+        }
+        segments.push(Segment { vaddr: sext(be32(p + 8)), memsz, flags: be32(p + 24), offset, filesz });
+    }
+    if segments.is_empty() {
+        return Err("no PT_LOAD segments — nothing to load".to_string());
+    }
+
+    Ok(Elf32 { entry: sext(be32(24)), segments })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal ELF32 MSB MIPS executable with one PT_LOAD segment.
+    fn build_elf(payload: &[u8], vaddr: u32, memsz: u32) -> Vec<u8> {
+        let mut v = vec![0u8; 52 + 32];
+        v[0..4].copy_from_slice(b"\x7fELF");
+        v[4] = 1; // ELFCLASS32
+        v[5] = 2; // ELFDATA2MSB
+        v[6] = 1; // EV_CURRENT
+        v[16..18].copy_from_slice(&2u16.to_be_bytes()); // ET_EXEC
+        v[18..20].copy_from_slice(&8u16.to_be_bytes()); // EM_MIPS
+        v[24..28].copy_from_slice(&vaddr.to_be_bytes()); // e_entry
+        v[28..32].copy_from_slice(&52u32.to_be_bytes()); // e_phoff
+        v[42..44].copy_from_slice(&32u16.to_be_bytes()); // e_phentsize
+        v[44..46].copy_from_slice(&1u16.to_be_bytes());  // e_phnum
+        let p = 52;
+        v[p..p + 4].copy_from_slice(&PT_LOAD.to_be_bytes());
+        v[p + 4..p + 8].copy_from_slice(&84u32.to_be_bytes()); // p_offset
+        v[p + 8..p + 12].copy_from_slice(&vaddr.to_be_bytes());
+        v[p + 16..p + 20].copy_from_slice(&(payload.len() as u32).to_be_bytes());
+        v[p + 20..p + 24].copy_from_slice(&memsz.to_be_bytes());
+        v[p + 24..p + 28].copy_from_slice(&5u32.to_be_bytes()); // r-x
+        v.extend_from_slice(payload);
+        v
+    }
+
+    #[test]
+    fn parses_a_static_be_mips_executable() {
+        let elf = parse(&build_elf(&[0x24, 0x02, 0x00, 0x01], 0x8010_0000, 0x100)).unwrap();
+        assert_eq!(elf.entry, 0xFFFF_FFFF_8010_0000, "32-bit vaddrs must be sign-extended");
+        assert_eq!(elf.segments.len(), 1);
+        let s = &elf.segments[0];
+        assert_eq!(s.vaddr, 0xFFFF_FFFF_8010_0000);
+        assert_eq!(s.filesz, 4);
+        assert_eq!(s.memsz, 0x100);
+        assert_eq!(flag_str(s.flags), "r-x");
+        assert_eq!(s.offset, 84);
+    }
+
+    #[test]
+    fn rejects_wrong_class_endianness_type_and_machine() {
+        let good = build_elf(&[0; 4], 0x8010_0000, 4);
+
+        let mut v = good.clone(); v[4] = 2;
+        assert!(parse(&v).unwrap_err().contains("ELF64"));
+        let mut v = good.clone(); v[5] = 1;
+        assert!(parse(&v).unwrap_err().contains("little-endian"));
+        let mut v = good.clone(); v[16..18].copy_from_slice(&3u16.to_be_bytes());
+        assert!(parse(&v).unwrap_err().contains("ET_DYN"));
+        let mut v = good.clone(); v[18..20].copy_from_slice(&243u16.to_be_bytes());
+        assert!(parse(&v).unwrap_err().contains("not a MIPS binary"));
+        let mut v = good.clone(); v[52..56].copy_from_slice(&PT_DYNAMIC.to_be_bytes());
+        assert!(parse(&v).unwrap_err().contains("dynamically linked"));
+
+        assert!(parse(b"not an elf at all, really truly not, padded out to 52 bytes ok").is_err());
+        assert!(parse(&[]).unwrap_err().contains("too short"));
+    }
+
+    #[test]
+    fn rejects_a_segment_that_runs_past_the_file() {
+        let mut v = build_elf(&[0; 4], 0x8010_0000, 4);
+        v[52 + 16..52 + 20].copy_from_slice(&0x1000u32.to_be_bytes()); // p_filesz
+        v[52 + 20..52 + 24].copy_from_slice(&0x1000u32.to_be_bytes()); // p_memsz
+        assert!(parse(&v).unwrap_err().contains("past the end"));
+    }
+}

--- a/src/gl_compositor.rs
+++ b/src/gl_compositor.rs
@@ -21,7 +21,7 @@ void main() {
 ";
 
 // Lookup tables (cmap/ramdac/xmap) are 2D textures with height=1 since
-// glow 0.13 does not expose tex_sub_image_1d. Use texelFetch(..., ivec2(addr, 0), 0).
+// glow does not expose tex_sub_image_1d. Use texelFetch(..., ivec2(addr, 0), 0).
 const FRAG_SRC: &str = "
 #version 150
 
@@ -268,7 +268,7 @@ impl GlCompositor {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_S, glow::CLAMP_TO_EDGE as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::CLAMP_TO_EDGE as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::R32UI as i32, w, h, 0,
-                glow::RED_INTEGER, glow::UNSIGNED_INT, None);
+                glow::RED_INTEGER, glow::UNSIGNED_INT, glow::PixelUnpackData::Slice(None));
             t
         }
     }
@@ -282,7 +282,7 @@ impl GlCompositor {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_S, glow::CLAMP_TO_EDGE as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_WRAP_T, glow::CLAMP_TO_EDGE as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::R8UI as i32, w, h, 0,
-                glow::RED_INTEGER, glow::UNSIGNED_BYTE, None);
+                glow::RED_INTEGER, glow::UNSIGNED_BYTE, glow::PixelUnpackData::Slice(None));
             t
         }
     }
@@ -303,7 +303,7 @@ impl GlCompositor {
             self.tex_aux    = Some(Self::make_2d_tex_r32ui(gl, FB_W, FB_H));
             self.tex_did    = Some(Self::make_2d_tex_r8ui (gl, FB_W, FB_H));
             self.tex_cursor = Some(Self::make_2d_tex_r8ui (gl, CURSOR_TEX_SIZE, CURSOR_TEX_SIZE));
-            // Lookup tables: height=1, width=N (since tex_sub_image_1d is not in glow 0.13)
+            // Lookup tables: height=1, width=N (since tex_sub_image_1d is not in glow)
             self.tex_cmap   = Some(Self::make_2d_tex_r32ui(gl, 8192, 1));
             self.tex_ramdac = Some(Self::make_2d_tex_r32ui(gl, 256,  1));
             self.tex_xmap   = Some(Self::make_2d_tex_r32ui(gl, 32,   1));
@@ -314,7 +314,7 @@ impl GlCompositor {
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MIN_FILTER, glow::NEAREST as i32);
             gl.tex_parameter_i32(glow::TEXTURE_2D, glow::TEXTURE_MAG_FILTER, glow::NEAREST as i32);
             gl.tex_image_2d(glow::TEXTURE_2D, 0, glow::RGBA as i32,
-                FB_W, FB_H, 0, glow::RGBA, glow::UNSIGNED_BYTE, None);
+                FB_W, FB_H, 0, glow::RGBA, glow::UNSIGNED_BYTE, glow::PixelUnpackData::Slice(None));
             self.tex_out = Some(tex_out);
 
             let fbo = gl.create_framebuffer().unwrap();
@@ -342,7 +342,7 @@ impl GlCompositor {
             gl.tex_sub_image_2d(
                 glow::TEXTURE_2D, 0, 0, 0, w, h,
                 glow::RED_INTEGER, glow::UNSIGNED_INT,
-                glow::PixelUnpackData::Slice(bytes),
+                glow::PixelUnpackData::Slice(Some(bytes)),
             );
             gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
         }
@@ -355,7 +355,7 @@ impl GlCompositor {
             gl.tex_sub_image_2d(
                 glow::TEXTURE_2D, 0, 0, 0, w, h,
                 glow::RED_INTEGER, glow::UNSIGNED_BYTE,
-                glow::PixelUnpackData::Slice(data),
+                glow::PixelUnpackData::Slice(Some(data)),
             );
             gl.pixel_store_i32(glow::UNPACK_ROW_LENGTH, 0);
         }
@@ -368,7 +368,7 @@ impl GlCompositor {
             gl.tex_sub_image_2d(
                 glow::TEXTURE_2D, 0, 0, 0, data.len() as i32, 1,
                 glow::RED_INTEGER, glow::UNSIGNED_INT,
-                glow::PixelUnpackData::Slice(bytes),
+                glow::PixelUnpackData::Slice(Some(bytes)),
             );
         }
     }
@@ -505,7 +505,7 @@ impl Compositor for GlCompositor {
                         glow::TEXTURE_2D, 0, 0, 0,
                         CURSOR_TEX_SIZE, CURSOR_TEX_SIZE,
                         glow::RED_INTEGER, glow::UNSIGNED_BYTE,
-                        glow::PixelUnpackData::Slice(&glyph),
+                        glow::PixelUnpackData::Slice(Some(&glyph)),
                     );
                 }
                 self.last_cursor_hash = ch;
@@ -630,7 +630,7 @@ impl Compositor for GlCompositor {
                     height as i32,
                     glow::RGBA,
                     glow::UNSIGNED_BYTE,
-                    glow::PixelPackData::Slice(&mut tight),
+                    glow::PixelPackData::Slice(Some(&mut tight)),
                 );
                 if pbo_guard.is_none() {
                     if let Ok(pbo) = gl.create_buffer() {

--- a/src/hpc3.rs
+++ b/src/hpc3.rs
@@ -1059,6 +1059,7 @@ impl Hpc3 {
         let net_mode = net.mode;
         let pcap_interface = net.pcap_interface;
         let nfs_pcap_ip = net.nfs_pcap_ip;
+        let tftp_dir = net.tftp_dir.clone();
         let rtc = Arc::new(Ds1x86::new(8192, nvram_path));
         let pdma_dump = Arc::new(AtomicU32::new(0));
         
@@ -1139,6 +1140,7 @@ impl Hpc3 {
             mode:       net_mode,
             pcap_interface,
             nfs_pcap_ip,
+            tftp_dir,
             ..GatewayConfig::default()
         };
         let net_base = gateway_cfg.clone();

--- a/src/iris_ci_main.rs
+++ b/src/iris_ci_main.rs
@@ -65,8 +65,12 @@ enum Cmd {
     Ping,
     /// Start the CPU thread (no-op if already running).
     Start,
-    /// Cleanly shut down iris.
-    Quit,
+    /// Cleanly shut down iris. `--sync-chd [ID|all]` folds pending CHD diffs
+    /// back into their bases first (default: all disks).
+    Quit {
+        #[arg(long, num_args = 0..=1, default_missing_value = "all", value_name = "ID|all")]
+        sync_chd: Option<String>,
+    },
 
     /// Save the current machine state to saves/<name>/.
     Save {
@@ -187,6 +191,13 @@ enum Cmd {
 
     /// Load an arbitrary CD image into a SCSI ID and make it the active disc.
     CdromLoad { id: u64, path: String },
+
+    /// Fold pending CHD diffs back into their bases (guest must be stopped).
+    ChdSync {
+        /// SCSI id to consolidate, or "all" (default).
+        #[arg(default_value = "all", value_name = "ID|all")]
+        id: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -258,7 +269,15 @@ fn dispatch(opts: &Opts, cmd: Cmd) -> Result<()> {
     match cmd {
         Cmd::Ping        => simple(opts, "ping", json!({}), "ok"),
         Cmd::Start       => simple(opts, "start", json!({}), "started"),
-        Cmd::Quit        => simple(opts, "quit", json!({}), "quit"),
+        Cmd::Quit { sync_chd } => match sync_chd {
+            // A fold recompresses the whole base, so it can far outrun the 300s default.
+            Some(sel) => {
+                let data = send_until(opts, "quit", json!({"sync_chd": scsi_sel(&sel)?}), FOLD_TIMEOUT)?;
+                print_response(opts, "quit", &data);
+                Ok(())
+            }
+            None => simple(opts, "quit", json!({}), "quit"),
+        },
         Cmd::Save { name, description } => {
             let mut args = json!({"name": name});
             if let Some(d) = description { args["description"] = Value::String(d); }
@@ -306,6 +325,11 @@ fn dispatch(opts: &Opts, cmd: Cmd) -> Result<()> {
         }
         Cmd::CdromEject { id } => simple(opts, "cdrom-eject", json!({"id": id}), "ejected"),
         Cmd::CdromLoad { id, path } => simple(opts, "cdrom-load", json!({"id": id, "path": path}), "loaded"),
+        Cmd::ChdSync { id } => {
+            let data = send_until(opts, "chd-sync", json!({"id": scsi_sel(&id)?}), FOLD_TIMEOUT)?;
+            print_response(opts, "synced", &data);
+            Ok(())
+        }
     }
 }
 
@@ -332,6 +356,17 @@ struct Opts {
 
 /// Read timeout for commands that answer promptly.
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(300);
+/// CHD folds recompress a whole base image, which can take far longer than the default.
+const FOLD_TIMEOUT: Duration = Duration::from_secs(3 * 3600);
+
+/// `"all"` stays a string; anything else must be a SCSI id 0-7.
+fn scsi_sel(s: &str) -> Result<Value> {
+    if s.eq_ignore_ascii_case("all") { return Ok(json!("all")); }
+    match s.parse::<u64>() {
+        Ok(n) if n < 8 => Ok(json!(n)),
+        _ => Err(Error::Iris(format!("bad scsi id '{s}' (expected 0-7 or \"all\")"))),
+    }
+}
 
 /// Grace on top of a guest deadline, so the server's own timeout fires first
 /// and reports which pattern was missed rather than the client giving up.

--- a/src/jit/codegen_test.rs
+++ b/src/jit/codegen_test.rs
@@ -107,6 +107,7 @@ mod tests {
         let mem = Arc::new(MockMemory::new());
         let bus: Arc<dyn BusDevice> = mem.clone();
         let cfg = MipsCpuConfig::indy();
+        #[cfg_attr(not(feature = "jitv2"), allow(unused_mut))] // only the jitv2 block below mutates it
         let mut exec = MipsExecutor::new(bus, PassthroughTlb::default(), &cfg);
         // This file predates jitv2 and never calls `install_jit_hooks` — a
         // jitv2 dispatch gate variant that intercepted a dispatch here would

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod exp;
 pub mod gdb_stub;
 pub mod snapshot;
 pub mod sgi_vh;
+pub mod elf;
 pub mod chunk_store;
 pub mod validate;
 pub mod registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub mod locks;
 pub mod pit8254;
 pub mod net;
 pub mod nfsudp;
+pub mod tftp;
+pub mod testdev;
 pub mod xdmcp;
 #[cfg(feature = "pcap")]
 pub mod net_pcap;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -553,6 +553,26 @@ impl Machine {
         }
 
         // 2. Create Physical Bus with devices
+        // `cfg` is shadowed by MipsCpuConfig further down; grab this first.
+        let cheritest_hook = cfg.cheritest_dump_hook;
+
+        // Bare-metal test device (--test-device): default off, and refused
+        // alongside the ultra64 dev board, which claims the same GIO slot.
+        let testdev = if cfg.test_device {
+            #[cfg(feature = "ultra64")]
+            if ultra64.is_some() {
+                eprintln!("iris: fatal: --test-device and the ultra64 dev board both claim GIO slot 0");
+                std::process::exit(1);
+            }
+            let path = cfg.test_device_dump.clone()
+                .unwrap_or_else(|| crate::testdev::DEFAULT_DUMP_PATH.to_string());
+            eprintln!("iris: test device enabled at {:#010x}, dumps to {}",
+                      crate::testdev::TEST_DEV_BASE, path);
+            Some(Arc::new(crate::testdev::TestDevice::new(path)))
+        } else {
+            None
+        };
+
         let phys_raw = Physical::new(
             banks,
             rex3.clone(),
@@ -561,6 +581,7 @@ impl Machine {
             mgras.clone(),
             #[cfg(feature = "ultra64")]
             ultra64,
+            testdev,
             vino,
             mc.clone(),
             hpc3.clone(),
@@ -703,6 +724,14 @@ impl Machine {
         // Machine::start) actually spawns the worker thread that reads it.
         if let Some(rex3) = &phys.rex3 { rex3.set_cpu_cycles(cpu.cycles_ptr()); }
         if let Some(rex3) = &phys.rex3_head1 { rex3.set_cpu_cycles(cpu.cycles_ptr()); }
+        if let Some(td) = &phys.testdev { td.attach_core(cpu.core_ptr()); }
+        if cheritest_hook {
+            if phys.testdev.is_none() {
+                eprintln!("iris: --cheritest-dump-hook needs --test-device; ignoring");
+            } else {
+                cpu.set_cheritest_dump_hook(true);
+            }
+        }
         hpc3.scsi().set_cpu_cycles(cpu.cycles_ptr());
 
         // Inject the CPU/self handles jitv2's compile-thread worker needs to
@@ -763,6 +792,7 @@ impl Machine {
         monitor.register_device(phys.clone());
         if let Some(rex3) = &phys.rex3 { monitor.register_device(rex3.clone()); }
         if let Some(rex3) = &phys.rex3_head1 { monitor.register_device(rex3.clone()); }
+        if let Some(td) = &phys.testdev { monitor.register_device(td.clone()); }
         if let Some(xz) = &phys.xz { monitor.register_device(xz.clone()); }
         if let Some(mgras) = &phys.mgras { monitor.register_device(mgras.clone()); }
         #[cfg(feature = "ultra64")]
@@ -1513,6 +1543,7 @@ impl Machine {
         self.hpc3.power_on();
         if let Some(rex3) = &self._phys.rex3 { rex3.power_on(); }
         if let Some(rex3) = &self._phys.rex3_head1 { rex3.power_on(); }
+        if let Some(td) = &self._phys.testdev { td.power_on(); }
         self.apply_host_display_resolution();
     }
 
@@ -1573,6 +1604,9 @@ impl Machine {
             if sv < 3 {
                 rex3.save_framebuffers(&snap.dir).map_err(|e| e.to_string())?;
             }
+        }
+        if let Some(td) = &self._phys.testdev {
+            snap.write_state("testdev", &td.save_state(), sv).map_err(|e| e.to_string())?;
         }
         if let Some(rex3) = &self._phys.rex3_head1 {
             snap.write_state("rex3_head1", &rex3.save_state(), sv).map_err(|e| e.to_string())?;
@@ -1824,6 +1858,11 @@ impl Machine {
             rex3.load_state(&rex3_v)?;
             if schema_version < 3 {
                 rex3.load_framebuffers(&snap.dir).map_err(|e| e.to_string())?;
+            }
+        }
+        if let Some(td) = &self._phys.testdev {
+            if let Ok(v) = snap.read_state("testdev", schema_version) {
+                td.load_state(&v)?;
             }
         }
         if let Some(rex3) = &self._phys.rex3_head1 {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1091,16 +1091,18 @@ impl Machine {
         self.hpc3.scsi().pending_chd_sync_count()
     }
 
-    /// Fold every pending CHD diff back into its base, preserving compression.
+    /// Fold pending CHD diffs back into their bases, preserving compression.
+    /// `only` limits it to one SCSI id; `None` means all.
     /// Call only after the guest has stopped (so disk I/O is quiesced).
     /// `progress(done, total, fraction)` drives a UI; `cancel()` aborts cleanly,
     /// leaving un-synced bases+diffs intact. Returns the count synced.
     pub fn sync_chd_disks(
         &self,
+        only: Option<usize>,
         progress: &mut dyn FnMut(usize, usize, f32),
         cancel: &dyn Fn() -> bool,
     ) -> std::io::Result<usize> {
-        self.hpc3.scsi().sync_chd_disks(progress, cancel)
+        self.hpc3.scsi().sync_chd_disks(only, progress, cancel)
     }
 
     /// Cumulative count of guest-originated Ethernet frames the NAT engine has

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1029,6 +1029,16 @@ impl Machine {
         MipsCpuDebugAdapter::new(self.cpu.clone())
     }
 
+    /// Load a static ELF32 MSB binary into RAM and set PC to its entry point
+    /// (`--load-elf`, and the monitor's `loadelf`). CPU must be stopped.
+    pub fn load_elf(&self, path: &str) -> Result<String, String> {
+        // Before POST every bank is invalid (MEMCFG0/1 = 0) and writes to RAM
+        // addresses go to UnmappedRam, so map the banks as POST would first.
+        let mapped = self.mc.post_map_banks();
+        let out = self.cpu.load_elf(path)?;
+        Ok(if mapped { format!("  (mapped RAM banks; POST has not run)\n{}", out) } else { out })
+    }
+
     /// The in-process serial backend used by `--ci` mode. `None` in
     /// interactive mode.
     pub fn get_ci_serial(&self) -> Option<Arc<crate::z85c30::CiSerialBackend>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
     let ci_enabled = cfg.ci;
     let ci_display = cfg.ci_display;
     let ci_socket_path = cfg.ci_socket.clone();
+    let load_elf = cfg.load_elf.clone();
 
     // Apply [jit] from TOML (env vars still override if set externally).
     cfg.jit.apply_env();
@@ -46,6 +47,20 @@ fn main() {
         .join()
         .unwrap();
     machine.register_system_controller();
+
+    // --load-elf: load before the CPU starts, so the binary runs instead of the
+    // PROM's boot path. RAM is already mapped at this point (Machine::new fires
+    // an initial remap_banks with the MC's power-on MEMCFG), so this lands in
+    // real RAM without POST having run.
+    if let Some(path) = &load_elf {
+        match machine.load_elf(path) {
+            Ok(summary) => eprint!("iris: loaded {}\n{}", path, summary),
+            Err(e) => {
+                eprintln!("iris: --load-elf {}: {}", path, e);
+                std::process::exit(1);
+            }
+        }
+    }
 
     // CI control socket: started after Machine::new so it can hand out the
     // machine pointer + CiSerialBackend to command handlers.

--- a/src/mc.rs
+++ b/src/mc.rs
@@ -350,6 +350,26 @@ impl MemoryController {
         Some((base, addr_mask, limit))
     }
 
+    /// Map the RAM banks at their conventional bases exactly as the PROM's POST
+    /// does, for running code with no PROM involved (`--load-elf`). Banks 2/3
+    /// are synthesized at HIMEM by the MEMCFG0 write itself. No-op once any
+    /// bank is valid, so this never overrides what POST decided.
+    pub fn post_map_banks(&self) -> bool {
+        use crate::physical::{BANK_SIZE, LOMEM_BASE};
+        let (m0, m1) = self.get_memcfg();
+        if m0 != 0 || m1 != 0 {
+            return false;
+        }
+        let half = |i: usize, base: u32| {
+            Self::encode_memcfg_half(base, self.ram_sizes[i]).unwrap_or(0) as u32
+        };
+        let memcfg0 = (half(0, LOMEM_BASE) << 16) | half(1, LOMEM_BASE + BANK_SIZE);
+        if memcfg0 == 0 {
+            return false;
+        }
+        self.write32(MC_BASE + REG_MEMCFG0, memcfg0) == BUS_OK
+    }
+
     /// Parse MEMCFG0/1 registers into 4 bank (base, addr_mask, limit) triples using the
     /// configured ram_sizes. Returns None for invalid/empty banks.
     pub fn parse_memcfg(&self, memcfg0: u32, memcfg1: u32) -> [Option<(u32, u32, u32)>; 4] {

--- a/src/mips_exec.rs
+++ b/src/mips_exec.rs
@@ -852,6 +852,10 @@ impl MipsCpuConfig {
 pub struct MipsExecutor<T: Tlb, C: MipsCache> {
     pub core: MipsCore,
     pub sysad: Arc<dyn BusDevice>,
+    /// cheritest convention (`--cheritest-dump-hook`): a guest write to CP0 26
+    /// dumps machine state via the test device. Off unless asked for — CP0 26
+    /// is ECC on a real R4400 and the PROM writes it during cache init.
+    cheritest_dump_hook: bool,
     pub tlb: T,
     pub cache: C,
     #[cfg(feature = "developer")]
@@ -1623,6 +1627,7 @@ impl<T: Tlb, C: MipsCache> MipsExecutor<T, C> {
         let mut executor = Self {
             core,
             sysad,
+            cheritest_dump_hook: false,
             tlb,
             cache,
             #[cfg(feature = "developer")]
@@ -4798,6 +4803,12 @@ impl<T: Tlb, C: MipsCache> MipsExecutor<T, C> {
     }
 
     fn handle_cp0_side_effects(&mut self, reg: u32) {
+        // cheritest: a write to CP0 26 triggers the test device's dump. Routed
+        // over the bus, so with no test device mapped it's an ignored GIO access.
+        if reg == 26 && self.cheritest_dump_hook {
+            self.sysad.write32(crate::testdev::TEST_DEV_BASE + crate::testdev::REG_DUMP,
+                               self.core.cp0_ecc);
+        }
         #[cfg(feature = "r5ksc_triton")]
         if reg == 16 {
             // CONFIG_SE (bit 12): wire L2 enable/disable to cache.
@@ -7734,6 +7745,18 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> MipsCpu<T, C> {
     /// cloneable `Arc`). Same process-lifetime validity argument as
     /// `interrupts_ptr` (fixed for the life of this `MipsCpu`, set once in
     /// `new()` after the executor reached its final address).
+    /// Enable the cheritest CP0-26 dump hook (`--cheritest-dump-hook`).
+    pub fn set_cheritest_dump_hook(&self, on: bool) {
+        self.executor.lock().cheritest_dump_hook = on;
+    }
+
+    /// Pointer to the executor's `MipsCore`, for devices that report CPU state
+    /// from the CPU thread itself (the test device's DUMP). Same
+    /// process-lifetime validity argument as `cycles_ptr`.
+    pub fn core_ptr(&self) -> *const crate::mips_core::MipsCore {
+        &self.executor.lock().core as *const crate::mips_core::MipsCore
+    }
+
     pub fn cycles_ptr(&self) -> crate::mips_core::CyclesPtr {
         self.cycles_ptr
     }

--- a/src/mips_exec.rs
+++ b/src/mips_exec.rs
@@ -7454,6 +7454,113 @@ fn parse_reg_name(arg: &str) -> Option<usize> {
     }
 }
 
+/// Copy `data` to `vaddr` and zero-fill out to `memsz`. Writes go through the
+/// CPU's virtual-address path, so KSEG0/KSEG1 mapping, the MC address mask and
+/// bank remapping all apply — never poke `Memory` behind the bus.
+fn load_range<T: Tlb, C: MipsCache>(
+    exec: &mut MipsExecutor<T, C>,
+    vaddr: u64,
+    data: &[u8],
+    memsz: u64,
+) -> Result<(), String> {
+    if memsz == 0 {
+        return Ok(());
+    }
+    probe_mapped(exec, vaddr)?;
+    probe_mapped(exec, vaddr.wrapping_add(memsz - 1))?;
+
+    let mut off = 0u64;
+    while off < memsz {
+        let addr = vaddr.wrapping_add(off);
+        let byte = |k: u64| *data.get((off + k) as usize).unwrap_or(&0) as u64;
+        let (size, val) = if memsz - off >= 4 && addr % 4 == 0 {
+            (4usize, (byte(0) << 24) | (byte(1) << 16) | (byte(2) << 8) | byte(3))
+        } else {
+            (1usize, byte(0))
+        };
+        let status = exec.debug_write(addr, val, size, full_mask_for_usize(size));
+        if status != EXEC_COMPLETE {
+            return Err(format!(
+                "write failed at {:#018x} (status {:#010x}) — is RAM mapped and addressable there?",
+                addr, status
+            ));
+        }
+        off += size as u64;
+    }
+    invalidate_loaded_range(exec, vaddr, memsz);
+    Ok(())
+}
+
+/// Unmapped physical addresses are backed by `UnmappedRam`, which accepts every
+/// write and reads back zero — so a write into the void is completely silent.
+/// Probe with a non-zero pattern before committing an image.
+///
+/// The probe goes to the bus, not through `debug_write`: KSEG0 is cacheable, so
+/// a cached write is absorbed by L1D and reads back fine with nothing behind it.
+/// The original word is put back, so this leaves no trace.
+fn probe_mapped<T: Tlb, C: MipsCache>(exec: &mut MipsExecutor<T, C>, vaddr: u64) -> Result<(), String> {
+    let tr = exec.debug_translate(vaddr);
+    if tr.is_exception() {
+        return Err(format!("{:#018x} does not translate (status {:#010x})", vaddr, tr.status));
+    }
+    let phys = tr.phys;
+    let unmapped = || {
+        Err(format!(
+            "nothing is mapped at {:#018x} (physical {:#010x}) — writes there go nowhere. \
+             The PROM maps RAM during POST: boot to the PROM prompt first, or use --load-elf, \
+             which maps the banks itself",
+            vaddr, phys
+        ))
+    };
+
+    const PATTERN: u32 = 0x5A5A_A5A5;
+    if phys % 4 == 0 {
+        let saved = exec.sysad.read32(phys);
+        if !saved.is_ok() || exec.sysad.write32(phys, PATTERN) != BUS_OK {
+            return unmapped();
+        }
+        let got = exec.sysad.read32(phys);
+        exec.sysad.write32(phys, saved.data);
+        if !got.is_ok() || got.data != PATTERN {
+            return unmapped();
+        }
+    } else {
+        let saved = exec.sysad.read8(phys);
+        if !saved.is_ok() || exec.sysad.write8(phys, PATTERN as u8) != BUS_OK {
+            return unmapped();
+        }
+        let got = exec.sysad.read8(phys);
+        exec.sysad.write8(phys, saved.data);
+        if !got.is_ok() || got.data != PATTERN as u8 {
+            return unmapped();
+        }
+    }
+    Ok(())
+}
+
+/// Drop stale cache copies of a just-loaded range: writeback+invalidate L1D and
+/// L2 so the new bytes reach memory, then invalidate L1I so a stale decoded
+/// instruction can never execute. The v1 JIT needs no explicit flush (its
+/// CodeCache dies with the CPU thread, and loading requires a stopped CPU);
+/// jitv2 self-invalidates from the per-page generation counter the writes bump.
+fn invalidate_loaded_range<T: Tlb, C: MipsCache>(exec: &mut MipsExecutor<T, C>, vaddr: u64, len: u64) {
+    let (_, iline) = exec.cache.get_config(CACH_PI);
+    let (_, dline) = exec.cache.get_config(CACH_PD);
+    let step = (iline.min(dline).max(4)) as u64;
+    let mut addr = vaddr & !(step - 1);
+    let end = vaddr.wrapping_add(len);
+    while addr < end {
+        let tr = exec.debug_translate(addr);
+        if !tr.is_exception() {
+            let phys = tr.phys as u64;
+            exec.cache.cache_op(C_HWBINV | CACH_PD, addr, phys);
+            exec.cache.cache_op(C_HWBINV | CACH_SD, addr, phys);
+            exec.cache.cache_op(C_HINV | CACH_PI, addr, phys);
+        }
+        addr = addr.wrapping_add(step);
+    }
+}
+
 fn parse_cpu_arg(arg: &str, core: &MipsCore, symbols: Option<&SymbolTable>) -> Result<u64, String> {
     exp::parse_and_eval(arg, core, symbols)
 }
@@ -7859,6 +7966,45 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> MipsCpu<T, C> {
 
     fn try_lock_executor(&self) -> Result<parking_lot::MutexGuard<'_, MipsExecutor<T, C>>, String> {
         self.executor.try_lock().ok_or_else(|| "CPU thread holds the executor lock; try 'cpu stop' first".to_string())
+    }
+
+    /// Load a static ELF32 MSB image: copy each `PT_LOAD` to its `p_vaddr`,
+    /// zero-fill to `p_memsz`, set PC to `e_entry`. Returns a segment summary.
+    pub fn load_elf(&self, path: &str) -> Result<String, String> {
+        let bytes = std::fs::read(path).map_err(|e| format!("{}: {}", path, e))?;
+        let elf = crate::elf::parse(&bytes).map_err(|e| format!("{}: {}", path, e))?;
+        self.check_stopped()?;
+        let mut exec = self.try_lock_executor()?;
+        let mut out = String::new();
+        for s in &elf.segments {
+            load_range(&mut exec, s.vaddr, &bytes[s.offset..s.offset + s.filesz], s.memsz)?;
+            out.push_str(&format!(
+                "  {:#018x}  filesz {:#x}  memsz {:#x}  {}\n",
+                s.vaddr, s.filesz, s.memsz, crate::elf::flag_str(s.flags)
+            ));
+        }
+        exec.core.pc = elf.entry;
+        out.push_str(&format!("  entry {:#018x}\n", elf.entry));
+        Ok(out)
+    }
+
+    /// Load raw bytes at a virtual address. PC is not touched.
+    pub fn load_bin(&self, path: &str, vaddr: u64) -> Result<String, String> {
+        let bytes = std::fs::read(path).map_err(|e| format!("{}: {}", path, e))?;
+        self.check_stopped()?;
+        let mut exec = self.try_lock_executor()?;
+        load_range(&mut exec, vaddr, &bytes, bytes.len() as u64)?;
+        Ok(format!("  {:#018x}  {} bytes\n", vaddr, bytes.len()))
+    }
+
+    /// Loading over live code races the running dispatch loop, and the v1 JIT's
+    /// CodeCache (owned by `run_jit_dispatch`, dropped when the CPU thread exits)
+    /// would keep translations of the code we just replaced.
+    fn check_stopped(&self) -> Result<(), String> {
+        if self.is_running() {
+            return Err("CPU is running — 'cpu stop' first".to_string());
+        }
+        Ok(())
     }
 
     /// Step the executor `n` times in-line on the calling thread. Caller must
@@ -8408,6 +8554,8 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> Device for MipsCpu<
             ("u".to_string(), "Alias for undo [DEV]".to_string()),
             ("sym".to_string(), "Lookup symbol: sym <addr>".to_string()),
             ("loadsym".to_string(), "Load symbols from file: loadsym <file>".to_string()),
+            ("loadelf".to_string(), "Load a static ELF32 MSB binary and set PC to its entry: loadelf <file>".to_string()),
+            ("loadbin".to_string(), "Load raw bytes at a virtual address: loadbin <file> <addr>".to_string()),
             ("proc".to_string(), "IRIX kernel introspection: proc info  (requires `loadsym` first)".to_string()),
             ("l1i".to_string(), "L1 Instruction Cache commands: l1i <check|dump> <addr|index>".to_string()),
             ("l1d".to_string(), "L1 Data Cache commands: l1d <check|dump> <addr|index>".to_string()),
@@ -9057,6 +9205,22 @@ impl<T: Tlb + Send + 'static, C: MipsCache + Send + 'static> Device for MipsCpu<
                         Err(_) => writeln!(writer, "{:#018x}: Could not fetch", curr_addr).unwrap(),
                     }
                 }
+                Ok(())
+            }
+            "loadelf" => {
+                if actual_args.is_empty() { return Err("Usage: loadelf <file>".to_string()); }
+                write!(writer, "{}", self.load_elf(actual_args[0])?).unwrap();
+                Ok(())
+            }
+            "loadbin" => {
+                if actual_args.len() < 2 { return Err("Usage: loadbin <file> <addr>".to_string()); }
+                let addr = {
+                    let exec = self.try_lock_executor()?;
+                    let symbols_arc = exec.symbols.clone();
+                    let symbols = symbols_arc.lock();
+                    parse_cpu_arg(actual_args[1], &exec.core, Some(&symbols))?
+                };
+                write!(writer, "{}", self.load_bin(actual_args[0], addr)?).unwrap();
                 Ok(())
             }
             "jump" => {

--- a/src/net.rs
+++ b/src/net.rs
@@ -32,6 +32,7 @@ const UDP_PORT_DNS:          u16 = 53;
 const UDP_PORT_PORTMAP:      u16 = 111;
 const UDP_PORT_TIME:         u16 = 37;
 const UDP_PORT_NTP:          u16 = 123;
+const UDP_PORT_TFTP:         u16 = 69;
 const XDMCP_GUEST_PORT:      u16 = 177;  // XDMCP control channel inside the guest
 const X11_BASE_PORT:         u16 = 6000; // X11 display N's TCP port = 6000 + N
 const TCP_PORT_TIME:         u16 = 37;
@@ -69,6 +70,9 @@ pub struct GatewayConfig {
     /// PCAP-only: virtual LAN IP the in-process NFS server answers on. `Some`
     /// together with `nfs` enables the bridged NFS responder ([`NfsVirtualHost`]).
     pub nfs_pcap_ip: Option<Ipv4Addr>,
+    /// Root directory served read-only over TFTP at the gateway, for PROM
+    /// network boot (`boot -f bootp()<file>`). None disables TFTP entirely.
+    pub tftp_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for GatewayConfig {
@@ -85,6 +89,7 @@ impl Default for GatewayConfig {
             mode:         NetMode::Nat,
             pcap_interface: None,
             nfs_pcap_ip:  None,
+            tftp_dir:     None,
         }
     }
 }
@@ -1068,6 +1073,11 @@ pub struct NatEngine {
     // real X server recorded here instead of the generic loopback. Populated by
     // the XDMCP UDP-forward hook in poll_udp_fwd_listeners.
     xdmcp_sessions: HashMap<u16, Ipv4Addr>,
+    // Read-only TFTP server for PROM network boot. Some when tftp_dir is set.
+    tftp: Option<crate::tftp::TftpServer>,
+    // MAC to reply to per TFTP client, so a retransmit can be addressed without
+    // relying on the last-learned guest MAC.
+    tftp_macs: HashMap<crate::tftp::ClientId, [u8; 6]>,
 }
 
 /// Reassembly state for one fragmented inbound IP datagram.
@@ -1154,6 +1164,10 @@ impl NatEngine {
             eprintln!("iris: in-core NFS server exporting {}", c.shared_dir);
             crate::nfsudp::NfsServer::new(c.shared_dir.clone(), c.version)
         });
+        let tftp = config.tftp_dir.as_ref().map(|dir| {
+            eprintln!("iris: TFTP server (read-only) serving {}", dir.display());
+            crate::tftp::TftpServer::new(dir.clone())
+        });
         Self { config, tx_cons, rx_prod, rx_wake, tx_wake, running, ctl,
                udp_nat: HashMap::new(), tcp_nat: HashMap::new(), tcp_tw: HashMap::new(),
                icmp_nat: HashMap::new(), icmp_unavailable: false, deferred_rx: Vec::new(),
@@ -1161,7 +1175,8 @@ impl NatEngine {
                tcp_fwd_pending: HashMap::new(), fwd_ephemeral_next: 49152,
                fwd_reserved_next: 512,
                guest_mac: None, ip_id: 1, nfs, frag_reasm: HashMap::new(),
-               xdmcp_sessions: HashMap::new() }
+               xdmcp_sessions: HashMap::new(),
+               tftp, tftp_macs: HashMap::new() }
     }
 
     /// Rebind the static port-forward listeners from a new rule set, live (no
@@ -1259,6 +1274,7 @@ impl NatEngine {
             self.poll_icmp();
             self.poll_tcp_fwd_listeners();
             self.poll_udp_fwd_listeners();
+            self.poll_tftp();
             self.update_snapshot();
         }
     }
@@ -1649,6 +1665,8 @@ impl NatEngine {
                               => self.handle_time_udp(src_mac, src_ip, sport),
             UDP_PORT_NTP  if dst_ip == self.config.gateway_ip
                               => self.handle_ntp_udp(src_mac, src_ip, sport, payload),
+            UDP_PORT_TFTP if self.tftp.is_some() && dst_ip == self.config.gateway_ip
+                              => self.handle_tftp_udp(src_mac, src_ip, sport, payload),
             _ => {
                 // NFS/mountd: rewrite destination to localhost high port before NAT.
                 let real_dst = self.nfs_remap_dst(dst_ip, dport);
@@ -1673,6 +1691,40 @@ impl NatEngine {
         self.ip_id = self.ip_id.wrapping_add(1);
         self.deferred_rx.extend(ip_frames_udp(
             client_mac, &self.config.gateway_mac, self.config.gateway_ip, client_ip, id, &udp));
+    }
+
+    // ── TFTP (read-only, PROM network boot) ───────────────────────────────────
+    /// Hand a guest TFTP datagram to the in-core server and inject its reply.
+    /// A reply always fits one 516-byte datagram, so no fragmentation is needed.
+    fn handle_tftp_udp(&mut self, client_mac: &[u8; 6], client_ip: Ipv4Addr,
+                       client_port: u16, payload: &[u8]) {
+        let client = (client_ip, client_port);
+        let Some(reply) = self.tftp.as_mut().and_then(|s| s.handle(client, payload, Instant::now()))
+        else { return };
+        dlog_dev!(LogModule::Net, "NAT TFTP {}:{} ← {} bytes", client_ip, client_port, reply.len());
+        self.tftp_macs.insert(client, *client_mac);
+        self.send_tftp(client, *client_mac, &reply);
+    }
+
+    /// Retransmit TFTP data the guest hasn't ACKed, and forget clients whose
+    /// transfer the server has given up on.
+    fn poll_tftp(&mut self) {
+        let Some(server) = self.tftp.as_mut() else { return };
+        let due = server.tick(Instant::now());
+        for (client, packet) in due {
+            let Some(mac) = self.tftp_macs.get(&client).copied() else { continue };
+            dlog_dev!(LogModule::Net, "NAT TFTP retransmit → {}:{}", client.0, client.1);
+            self.send_tftp(client, mac, &packet);
+        }
+        let server = self.tftp.as_ref().unwrap();
+        self.tftp_macs.retain(|client, _| server.has_transfer(client));
+    }
+
+    fn send_tftp(&mut self, client: crate::tftp::ClientId, mac: [u8; 6], packet: &[u8]) {
+        let udp = udp_packet(self.config.gateway_ip, client.0, UDP_PORT_TFTP, client.1, packet);
+        let frame = ip_frame(&mac, &self.config.gateway_mac,
+                             self.config.gateway_ip, client.0, IP_PROTO_UDP, &udp);
+        self.deferred_rx.push(frame);
     }
 
     // ── BOOTP / DHCP ──────────────────────────────────────────────────────────

--- a/src/net.rs
+++ b/src/net.rs
@@ -950,6 +950,111 @@ mod ftp_alg_tests {
     }
 }
 
+#[cfg(test)]
+mod tftp_nat_tests {
+    use super::*;
+
+    fn tmp_root(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+        let d = std::env::temp_dir().join(format!("iris-nat-tftp-{}-{}", tag, nanos));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// A NAT engine serving `root` over TFTP, with the rings a real one uses.
+    fn engine(root: &std::path::Path) -> (NatEngine, rtrb::Consumer<Vec<u8>>) {
+        let (_tx_prod, tx_cons) = rtrb::RingBuffer::new(8);
+        let (rx_prod, rx_cons) = rtrb::RingBuffer::new(8);
+        let config = GatewayConfig { tftp_dir: Some(root.to_path_buf()), ..GatewayConfig::default() };
+        let e = NatEngine::new(
+            config, tx_cons, rx_prod,
+            Arc::new((Mutex::new(()), Condvar::new())),
+            Arc::new((Mutex::new(()), Condvar::new())),
+            Arc::new(AtomicBool::new(true)),
+            NatControl::new(),
+        );
+        (e, rx_cons)
+    }
+
+    /// Guest → gateway UDP 69 frame carrying `payload`.
+    fn guest_frame(e: &NatEngine, guest_mac: &[u8; 6], sport: u16, payload: &[u8]) -> Vec<u8> {
+        let guest_ip = e.config.client_ip;
+        let gw_ip = e.config.gateway_ip;
+        let udp = udp_packet(guest_ip, gw_ip, sport, UDP_PORT_TFTP, payload);
+        ip_frame(&e.config.gateway_mac, guest_mac, guest_ip, gw_ip, IP_PROTO_UDP, &udp)
+    }
+
+    /// The reply's (src_port, dst_port, payload).
+    fn parse_reply(frame: &[u8]) -> (u16, u16, Vec<u8>) {
+        let ihl = ((frame[14] & 0x0F) as usize) * 4;
+        let udp = &frame[14 + ihl..];
+        (r16(udp, 0), r16(udp, 2), udp[8..].to_vec())
+    }
+
+    #[test]
+    fn rrq_through_the_nat_returns_data_from_the_gateway() {
+        let root = tmp_root("rrq");
+        let data: Vec<u8> = (0..700u32).map(|i| (i * 7) as u8).collect();
+        std::fs::write(root.join("cputest"), &data).unwrap();
+        let (mut e, _rx) = engine(&root);
+        let guest_mac = [0x08, 0x00, 0x69, 0x11, 0x22, 0x33];
+
+        let mut rrq = vec![0, 1];
+        rrq.extend_from_slice(b"cputest\0octet\0");
+        e.process(&guest_frame(&e, &guest_mac, 4242, &rrq));
+
+        assert_eq!(e.deferred_rx.len(), 1, "one DATA datagram back");
+        let (sport, dport, payload) = parse_reply(&e.deferred_rx[0]);
+        assert_eq!(sport, UDP_PORT_TFTP, "reply comes from the gateway's TFTP port");
+        assert_eq!(dport, 4242, "reply goes back to the client's TID");
+        assert_eq!(u16::from_be_bytes([payload[0], payload[1]]), 3, "opcode DATA");
+        assert_eq!(u16::from_be_bytes([payload[2], payload[3]]), 1, "block 1");
+        assert_eq!(&payload[4..], &data[..512]);
+        // Frame is addressed to the guest, from the gateway.
+        assert_eq!(&e.deferred_rx[0][0..6], &guest_mac);
+        assert_eq!(&e.deferred_rx[0][6..12], &e.config.gateway_mac);
+
+        // ACK 1 draws the short final block, which ends the transfer.
+        e.deferred_rx.clear();
+        e.process(&guest_frame(&e, &guest_mac, 4242, &[0, 4, 0, 1]));
+        let (_, _, payload) = parse_reply(&e.deferred_rx[0]);
+        assert_eq!(u16::from_be_bytes([payload[2], payload[3]]), 2, "block 2");
+        assert_eq!(&payload[4..], &data[512..], "188 remaining bytes");
+
+        e.deferred_rx.clear();
+        e.process(&guest_frame(&e, &guest_mac, 4242, &[0, 4, 0, 2]));
+        assert!(e.deferred_rx.is_empty(), "final ACK ends the transfer silently");
+        // The per-client MAC is dropped by the poll tick that follows, which is
+        // also the retransmit path — and it must have nothing left to resend.
+        e.poll_tftp();
+        assert!(e.tftp_macs.is_empty(), "client bookkeeping is dropped with the transfer");
+        assert!(e.deferred_rx.is_empty(), "a completed transfer never retransmits");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn tftp_is_inert_when_no_directory_is_configured() {
+        let (_tx_prod, tx_cons) = rtrb::RingBuffer::new(8);
+        let (rx_prod, _rx_cons) = rtrb::RingBuffer::new(8);
+        let mut e = NatEngine::new(
+            GatewayConfig::default(), tx_cons, rx_prod,
+            Arc::new((Mutex::new(()), Condvar::new())),
+            Arc::new((Mutex::new(()), Condvar::new())),
+            Arc::new(AtomicBool::new(true)),
+            NatControl::new(),
+        );
+        let guest_mac = [0x08, 0x00, 0x69, 0x11, 0x22, 0x33];
+        let mut rrq = vec![0, 1];
+        rrq.extend_from_slice(b"anything\0octet\0");
+        e.process(&guest_frame(&e, &guest_mac, 4242, &rrq));
+        assert!(e.tftp.is_none());
+        // Falls through to the generic NAT path, so no reply is generated here.
+        assert!(e.deferred_rx.is_empty());
+    }
+}
+
 #[cfg(all(test, feature = "pcap"))]
 mod nfs_pcap_tests {
     use super::*;

--- a/src/physical.rs
+++ b/src/physical.rs
@@ -204,6 +204,8 @@ pub struct Physical {
     pub mgras: Option<Arc<Mgras>>,
     #[cfg(feature = "ultra64")]
     pub ultra64: Option<Arc<Ultra64>>,
+    /// Bare-metal test device (`--test-device`), in GIO expansion slot 0.
+    pub testdev: Option<Arc<crate::testdev::TestDevice>>,
     pub vino: Vino,
     mc: MemoryController,
     hpc3: Hpc3,
@@ -272,6 +274,7 @@ impl Physical {
         mgras: Option<Arc<Mgras>>,
         #[cfg(feature = "ultra64")]
         ultra64: Option<Arc<Ultra64>>,
+        testdev: Option<Arc<crate::testdev::TestDevice>>,
         vino: Vino,
         mc: MemoryController,
         hpc3: Hpc3,
@@ -310,6 +313,7 @@ impl Physical {
             mgras,
             #[cfg(feature = "ultra64")]
             ultra64,
+            testdev,
             vino,
             mc,
             hpc3,
@@ -440,6 +444,16 @@ impl Physical {
             }
         }
         // GIO expansion slot 1 — second Newport when rex3_head1 absent: GIO timeout remains
+
+        // Test device (--test-device): GIO expansion slot 0, which is empty on a
+        // stock Indy and otherwise answers with a GIO timeout. See testdev.rs.
+        if let Some(td) = self.testdev.as_deref() {
+            let td_ptr: *const dyn BusDevice = td;
+            use crate::testdev::{TEST_DEV_BASE, TEST_DEV_SIZE};
+            for i in (TEST_DEV_BASE >> 16)..((TEST_DEV_BASE + TEST_DEV_SIZE - 1) >> 16) + 1 {
+                self.device_map[i as usize] = td_ptr;
+            }
+        }
 
         // Map MC registers (128KB at 0x1FA00000)
         for i in (MC_BASE >> 16)..((MC_END - 1) >> 16) + 1 {

--- a/src/sgi_vh.rs
+++ b/src/sgi_vh.rs
@@ -203,6 +203,14 @@ impl VolumeHeader {
 
     pub fn as_bytes(&self) -> &[u8; SECTOR_SIZE as usize] { &self.raw }
 
+    /// `vh_rootpt` / `vh_swappt`: default root and swap partition numbers.
+    pub fn root_swap_parts(&self) -> (u16, u16) {
+        (
+            u16::from_be_bytes(self.raw[4..6].try_into().unwrap()),
+            u16::from_be_bytes(self.raw[6..8].try_into().unwrap()),
+        )
+    }
+
     /// Default boot file (`vh_bootfile`), NUL-trimmed.
     pub fn bootfile(&self) -> String {
         trim_nul(&self.raw[BOOTFILE_OFFSET..BOOTFILE_OFFSET + BOOTFILE_LEN])
@@ -309,10 +317,14 @@ fn trim_nul(bytes: &[u8]) -> String {
 }
 
 /// One partition-table slot in an image description, with optional raw contents.
+///
+/// `first_block: None` places the partition immediately after the volume-header
+/// partition, the way SGI's own media does — on the 6.5.22 Installation Tools CD
+/// partition 7 starts at block 48736, exactly partition 8's length.
 #[derive(Clone, Debug)]
 pub struct PartitionSpec {
     pub slot: usize,
-    pub first_block: u32,
+    pub first_block: Option<u32>,
     pub nblks: u32,
     pub ptype: u32,
     pub content: Option<std::path::PathBuf>,
@@ -353,18 +365,32 @@ pub fn build_image(path: &Path, spec: &ImageSpec) -> io::Result<Vec<VolDirEntry>
     let bootfile = spec.bootfile.clone().or_else(|| spec.files.first().map(|(n, _)| n.clone()));
     if let Some(name) = bootfile { vh.set_bootfile(&name)?; }
 
-    // Slot 8 is the volume header partition by SGI convention; size it to cover the files.
-    if !spec.partitions.iter().any(|p| p.slot == 8) {
-        vh.set_partition(8, lbn.max(VH_SECTORS as u32), 0, PT_VOLHDR)?;
-    }
-    for p in &spec.partitions {
-        vh.set_partition(p.slot, p.nblks, p.first_block, p.ptype)?;
+    // Slot 8 is the volume header partition by SGI convention, and it must span
+    // every file the voldir points at — the 6.5.22 Installation Tools CD gives it
+    // 48736 blocks for ~24 MB of sash/miniroot, not the 8-block scratch minimum.
+    let vh_blocks = lbn.max(VH_SECTORS as u32);
+    let vh_blocks = spec
+        .partitions
+        .iter()
+        .find(|p| p.slot == 8)
+        .map_or(vh_blocks, |p| p.nblks.max(vh_blocks));
+    vh.set_partition(8, vh_blocks, 0, PT_VOLHDR)?;
+
+    // A partition with no explicit first_block starts right after the header.
+    let placed_parts: Vec<(usize, u32, u32, u32, Option<&std::path::PathBuf>)> = spec
+        .partitions
+        .iter()
+        .filter(|p| p.slot != 8)
+        .map(|p| (p.slot, p.first_block.unwrap_or(vh_blocks), p.nblks, p.ptype, p.content.as_ref()))
+        .collect();
+    for (slot, first, nblks, ptype, _) in &placed_parts {
+        vh.set_partition(*slot, *nblks, *first, *ptype)?;
     }
 
     // End of the last byte any partition or file claims, rounded up to a sector.
-    let mut end_blocks = lbn as u64;
-    for p in &spec.partitions {
-        end_blocks = end_blocks.max(p.first_block as u64 + p.nblks as u64);
+    let mut end_blocks = vh_blocks as u64;
+    for (_, first, nblks, _, _) in &placed_parts {
+        end_blocks = end_blocks.max(*first as u64 + *nblks as u64);
     }
     let total_bytes = if spec.total_bytes == 0 {
         end_blocks * SECTOR_SIZE
@@ -385,7 +411,7 @@ pub fn build_image(path: &Path, spec: &ImageSpec) -> io::Result<Vec<VolDirEntry>
     };
 
     // Slot 10 ("vol") covers the whole disk, as create_scratch_image does.
-    if !spec.partitions.iter().any(|p| p.slot == 10) {
+    if !placed_parts.iter().any(|(slot, ..)| *slot == 10) {
         vh.set_partition(10, (total_bytes / SECTOR_SIZE) as u32, 0, PT_VOLUME)?;
     }
 
@@ -396,17 +422,17 @@ pub fn build_image(path: &Path, spec: &ImageSpec) -> io::Result<Vec<VolDirEntry>
         f.seek(SeekFrom::Start(*block as u64 * SECTOR_SIZE))?;
         f.write_all(data)?;
     }
-    for p in &spec.partitions {
-        let Some(src) = &p.content else { continue };
+    for (slot, first, nblks, _, content) in &placed_parts {
+        let Some(src) = content else { continue };
         let data = std::fs::read(src)
             .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", src.display(), e)))?;
-        if data.len() as u64 > p.nblks as u64 * SECTOR_SIZE {
+        if data.len() as u64 > *nblks as u64 * SECTOR_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("{} ({} bytes) does not fit partition {} ({} blocks)", src.display(), data.len(), p.slot, p.nblks),
+                format!("{} ({} bytes) does not fit partition {} ({} blocks)", src.display(), data.len(), slot, nblks),
             ));
         }
-        f.seek(SeekFrom::Start(p.first_block as u64 * SECTOR_SIZE))?;
+        f.seek(SeekFrom::Start(*first as u64 * SECTOR_SIZE))?;
         f.write_all(&data)?;
     }
     f.sync_all()?;
@@ -572,7 +598,7 @@ mod tests {
             total_bytes: 1024 * 1024,
             bootfile: None,
             files: vec![("cputest".into(), payload.clone())],
-            partitions: vec![PartitionSpec { slot: 7, first_block: 64, nblks: 128, ptype: PT_RAW, content: None }],
+            partitions: vec![PartitionSpec { slot: 7, first_block: Some(64), nblks: 128, ptype: PT_RAW, content: None }],
         };
         let placed = build_image(&p, &spec).expect("build");
         assert_eq!(placed.len(), 1);
@@ -597,6 +623,34 @@ mod tests {
 
         let _ = std::fs::remove_file(&p);
         let _ = std::fs::remove_file(&payload);
+    }
+
+    #[test]
+    fn volume_header_partition_spans_the_voldir_payload() {
+        // The 6.5.22 Installation Tools CD gives slot 8 48736 blocks to cover
+        // sash/miniroot; 8 blocks is only right for a header with no files.
+        let p = unique_tmp_path("vhspan");
+        let big = unique_tmp_path("vhspan-file");
+        std::fs::write(&big, vec![0x55u8; 100 * SECTOR_SIZE as usize + 3]).unwrap();
+        let spec = ImageSpec {
+            files: vec![("sash".into(), big.clone())],
+            partitions: vec![PartitionSpec { slot: 7, first_block: None, nblks: 64, ptype: 5, content: None }],
+            ..Default::default()
+        };
+        let placed = build_image(&p, &spec).expect("build");
+        let vh = VolumeHeader::from_bytes(&std::fs::read(&p).unwrap()).unwrap();
+
+        let part8 = vh.partitions().into_iter().find(|e| e.slot == 8).expect("slot 8");
+        let file_end = placed[0].lbn + placed[0].nbytes.div_ceil(SECTOR_SIZE as u32);
+        assert!(part8.nblks >= file_end, "slot 8 ({} blocks) must span the voldir payload (ends at {})", part8.nblks, file_end);
+
+        // first_block: None starts the filesystem right after the header, as the CD does.
+        let part7 = vh.partitions().into_iter().find(|e| e.slot == 7).expect("slot 7");
+        assert_eq!(part7.first_block, part8.nblks, "partition 7 must begin where partition 8 ends");
+        assert_eq!(part7.ptype, 5, "SGI ships EFS filesystems as PT_SYSV");
+
+        let _ = std::fs::remove_file(&p);
+        let _ = std::fs::remove_file(&big);
     }
 
     #[test]

--- a/src/sgi_vh.rs
+++ b/src/sgi_vh.rs
@@ -31,7 +31,7 @@
 //! All values are big-endian per SGI convention.
 
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::{self, Seek, SeekFrom, Write};
 use std::path::Path;
 
 /// First payload byte. Reserved bytes 0..4095 hold the 8-sector VH partition.
@@ -129,6 +129,294 @@ fn fix_csum(vh: &mut [u8; SECTOR_SIZE as usize]) {
     vh[CSUM_OFFSET..CSUM_OFFSET + 4].copy_from_slice(&csum.to_be_bytes());
 }
 
+// ---------------------------------------------------------------------------
+// Volume directory: named standalone files the PROM boots by name, e.g.
+// `boot -f dksc(0,1,8)cputest`. 15 entries of 16 bytes at 0x048.
+// ---------------------------------------------------------------------------
+
+const BOOTFILE_OFFSET: usize = 0x008;
+const BOOTFILE_LEN: usize = 16;
+const VD_OFFSET: usize = 0x048;
+const VD_ENTRY_SIZE: usize = 16;
+/// Volume directory slots in `struct volume_header`.
+pub const VD_MAX_ENTRIES: usize = 15;
+/// `vd_name` is 8 bytes, NUL-padded and *not* NUL-terminated when full.
+pub const VD_NAME_LEN: usize = 8;
+/// Partition-table slots in `struct volume_header`.
+pub const PT_MAX_ENTRIES: usize = 16;
+
+/// One volume-directory entry. `lbn` is a 512-byte block from the start of the
+/// volume; `nbytes` is the exact file length.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VolDirEntry {
+    pub name: String,
+    pub lbn: u32,
+    pub nbytes: u32,
+}
+
+/// One partition-table entry, with the slot it occupies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PartEntry {
+    pub slot: usize,
+    pub nblks: u32,
+    pub first_block: u32,
+    pub ptype: u32,
+}
+
+/// A 512-byte SGI volume header, mutable in place. Every mutation refreshes the
+/// checksum, so `as_bytes()` is always valid to write to sector 0.
+#[derive(Clone)]
+pub struct VolumeHeader {
+    raw: [u8; SECTOR_SIZE as usize],
+}
+
+impl Default for VolumeHeader {
+    fn default() -> Self { Self::new() }
+}
+
+impl VolumeHeader {
+    /// An empty header: magic + valid checksum, no files, no partitions.
+    pub fn new() -> Self {
+        let mut raw = [0u8; SECTOR_SIZE as usize];
+        raw[0..4].copy_from_slice(&SGI_MAGIC.to_be_bytes());
+        let mut vh = Self { raw };
+        fix_csum(&mut vh.raw);
+        vh
+    }
+
+    /// Parse sector 0 of an existing image. Rejects anything without SGI magic.
+    pub fn from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        if bytes.len() < SECTOR_SIZE as usize {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "volume header is shorter than 512 bytes"));
+        }
+        let magic = u32::from_be_bytes(bytes[0..4].try_into().unwrap());
+        if magic != SGI_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("bad SGI magic {:#010x} (expected {:#010x})", magic, SGI_MAGIC),
+            ));
+        }
+        let mut raw = [0u8; SECTOR_SIZE as usize];
+        raw.copy_from_slice(&bytes[..SECTOR_SIZE as usize]);
+        Ok(Self { raw })
+    }
+
+    pub fn as_bytes(&self) -> &[u8; SECTOR_SIZE as usize] { &self.raw }
+
+    /// Default boot file (`vh_bootfile`), NUL-trimmed.
+    pub fn bootfile(&self) -> String {
+        trim_nul(&self.raw[BOOTFILE_OFFSET..BOOTFILE_OFFSET + BOOTFILE_LEN])
+    }
+
+    pub fn set_bootfile(&mut self, name: &str) -> io::Result<()> {
+        if name.len() > BOOTFILE_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("bootfile name '{}' exceeds {} characters", name, BOOTFILE_LEN),
+            ));
+        }
+        self.raw[BOOTFILE_OFFSET..BOOTFILE_OFFSET + BOOTFILE_LEN].fill(0);
+        self.raw[BOOTFILE_OFFSET..BOOTFILE_OFFSET + name.len()].copy_from_slice(name.as_bytes());
+        fix_csum(&mut self.raw);
+        Ok(())
+    }
+
+    /// Record a file in the first free voldir slot.
+    pub fn add_file(&mut self, name: &str, lbn: u32, nbytes: u32) -> io::Result<()> {
+        if name.is_empty() || name.len() > VD_NAME_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("voldir name '{}' must be 1..={} characters", name, VD_NAME_LEN),
+            ));
+        }
+        if !name.is_ascii() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, format!("voldir name '{}' must be ASCII", name)));
+        }
+        let slot = (0..VD_MAX_ENTRIES)
+            .find(|&i| self.raw[VD_OFFSET + i * VD_ENTRY_SIZE] == 0)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("volume directory is full ({} entries)", VD_MAX_ENTRIES),
+                )
+            })?;
+        let off = VD_OFFSET + slot * VD_ENTRY_SIZE;
+        self.raw[off..off + VD_ENTRY_SIZE].fill(0);
+        self.raw[off..off + name.len()].copy_from_slice(name.as_bytes());
+        self.raw[off + 8..off + 12].copy_from_slice(&lbn.to_be_bytes());
+        self.raw[off + 12..off + 16].copy_from_slice(&nbytes.to_be_bytes());
+        fix_csum(&mut self.raw);
+        Ok(())
+    }
+
+    /// Every non-empty voldir entry, in slot order.
+    pub fn files(&self) -> Vec<VolDirEntry> {
+        (0..VD_MAX_ENTRIES)
+            .filter_map(|i| {
+                let off = VD_OFFSET + i * VD_ENTRY_SIZE;
+                if self.raw[off] == 0 { return None; }
+                Some(VolDirEntry {
+                    name: trim_nul(&self.raw[off..off + VD_NAME_LEN]),
+                    lbn: u32::from_be_bytes(self.raw[off + 8..off + 12].try_into().unwrap()),
+                    nbytes: u32::from_be_bytes(self.raw[off + 12..off + 16].try_into().unwrap()),
+                })
+            })
+            .collect()
+    }
+
+    pub fn set_partition(&mut self, slot: usize, nblks: u32, first_block: u32, ptype: u32) -> io::Result<()> {
+        if slot >= PT_MAX_ENTRIES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("partition slot {} out of range (0..{})", slot, PT_MAX_ENTRIES),
+            ));
+        }
+        write_pt_entry(&mut self.raw, slot, nblks, first_block, ptype);
+        fix_csum(&mut self.raw);
+        Ok(())
+    }
+
+    /// Every partition slot with a non-zero size, in slot order.
+    pub fn partitions(&self) -> Vec<PartEntry> {
+        (0..PT_MAX_ENTRIES)
+            .filter_map(|slot| {
+                let off = PT_TABLE_OFFSET + slot * PT_ENTRY_SIZE;
+                let nblks = u32::from_be_bytes(self.raw[off..off + 4].try_into().unwrap());
+                if nblks == 0 { return None; }
+                Some(PartEntry {
+                    slot,
+                    nblks,
+                    first_block: u32::from_be_bytes(self.raw[off + 4..off + 8].try_into().unwrap()),
+                    ptype: u32::from_be_bytes(self.raw[off + 8..off + 12].try_into().unwrap()),
+                })
+            })
+            .collect()
+    }
+
+    /// True when the 128 big-endian words sum to zero, as IRIX and the PROM check.
+    pub fn csum_valid(&self) -> bool {
+        let mut sum: u32 = 0;
+        for chunk in self.raw.chunks_exact(4) {
+            sum = sum.wrapping_add(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        }
+        sum == 0
+    }
+}
+
+fn trim_nul(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+/// One partition-table slot in an image description, with optional raw contents.
+#[derive(Clone, Debug)]
+pub struct PartitionSpec {
+    pub slot: usize,
+    pub first_block: u32,
+    pub nblks: u32,
+    pub ptype: u32,
+    pub content: Option<std::path::PathBuf>,
+}
+
+/// Description of a bootable raw image: voldir files plus partition entries.
+#[derive(Clone, Debug, Default)]
+pub struct ImageSpec {
+    /// Image size in bytes; 0 sizes the image to fit its contents.
+    pub total_bytes: u64,
+    /// `vh_bootfile`; defaults to the first voldir file.
+    pub bootfile: Option<String>,
+    /// Voldir name -> host file to copy in.
+    pub files: Vec<(String, std::path::PathBuf)>,
+    pub partitions: Vec<PartitionSpec>,
+}
+
+/// Build a complete raw image from `spec` and return the placed voldir entries.
+///
+/// Files are laid out sector-aligned starting at block `VH_SECTORS`, and the
+/// volume-header partition (slot 8) is sized to cover them unless the caller
+/// supplies slot 8 itself.
+pub fn build_image(path: &Path, spec: &ImageSpec) -> io::Result<Vec<VolDirEntry>> {
+    let mut vh = VolumeHeader::new();
+    let mut placed: Vec<(u32, Vec<u8>)> = Vec::new();
+    let mut lbn = VH_SECTORS as u32;
+
+    for (name, src) in &spec.files {
+        let data = std::fs::read(src)
+            .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", src.display(), e)))?;
+        let nbytes = u32::try_from(data.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("{} is larger than 4 GB", src.display())))?;
+        vh.add_file(name, lbn, nbytes)?;
+        lbn += sectors_for(data.len() as u64) as u32;
+        placed.push((lbn - sectors_for(data.len() as u64) as u32, data));
+    }
+
+    let bootfile = spec.bootfile.clone().or_else(|| spec.files.first().map(|(n, _)| n.clone()));
+    if let Some(name) = bootfile { vh.set_bootfile(&name)?; }
+
+    // Slot 8 is the volume header partition by SGI convention; size it to cover the files.
+    if !spec.partitions.iter().any(|p| p.slot == 8) {
+        vh.set_partition(8, lbn.max(VH_SECTORS as u32), 0, PT_VOLHDR)?;
+    }
+    for p in &spec.partitions {
+        vh.set_partition(p.slot, p.nblks, p.first_block, p.ptype)?;
+    }
+
+    // End of the last byte any partition or file claims, rounded up to a sector.
+    let mut end_blocks = lbn as u64;
+    for p in &spec.partitions {
+        end_blocks = end_blocks.max(p.first_block as u64 + p.nblks as u64);
+    }
+    let total_bytes = if spec.total_bytes == 0 {
+        end_blocks * SECTOR_SIZE
+    } else {
+        if spec.total_bytes % SECTOR_SIZE != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("image size {} is not a multiple of {} bytes", spec.total_bytes, SECTOR_SIZE),
+            ));
+        }
+        if spec.total_bytes < end_blocks * SECTOR_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("image size {} is too small for its contents ({} bytes)", spec.total_bytes, end_blocks * SECTOR_SIZE),
+            ));
+        }
+        spec.total_bytes
+    };
+
+    // Slot 10 ("vol") covers the whole disk, as create_scratch_image does.
+    if !spec.partitions.iter().any(|p| p.slot == 10) {
+        vh.set_partition(10, (total_bytes / SECTOR_SIZE) as u32, 0, PT_VOLUME)?;
+    }
+
+    let mut f = File::create(path)?;
+    f.set_len(total_bytes)?;
+    f.write_all(vh.as_bytes())?;
+    for (block, data) in &placed {
+        f.seek(SeekFrom::Start(*block as u64 * SECTOR_SIZE))?;
+        f.write_all(data)?;
+    }
+    for p in &spec.partitions {
+        let Some(src) = &p.content else { continue };
+        let data = std::fs::read(src)
+            .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", src.display(), e)))?;
+        if data.len() as u64 > p.nblks as u64 * SECTOR_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{} ({} bytes) does not fit partition {} ({} blocks)", src.display(), data.len(), p.slot, p.nblks),
+            ));
+        }
+        f.seek(SeekFrom::Start(p.first_block as u64 * SECTOR_SIZE))?;
+        f.write_all(&data)?;
+    }
+    f.sync_all()?;
+    Ok(vh.files())
+}
+
+fn sectors_for(bytes: u64) -> u64 {
+    bytes.div_ceil(SECTOR_SIZE)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +505,112 @@ mod tests {
         let p = unique_tmp_path("misaligned");
         let r = create_scratch_image(&p, 4096 + 100);
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn voldir_round_trips() {
+        let mut vh = VolumeHeader::new();
+        vh.add_file("sash", 4, 300_000).unwrap();
+        vh.add_file("cputest", 1024, 8192).unwrap();
+        let files = vh.files();
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0], VolDirEntry { name: "sash".into(), lbn: 4, nbytes: 300_000 });
+        assert_eq!(files[1], VolDirEntry { name: "cputest".into(), lbn: 1024, nbytes: 8192 });
+
+        let reparsed = VolumeHeader::from_bytes(vh.as_bytes()).unwrap();
+        assert_eq!(reparsed.files(), files);
+        assert!(reparsed.csum_valid());
+    }
+
+    #[test]
+    fn eight_char_name_is_not_nul_terminated() {
+        let mut vh = VolumeHeader::new();
+        vh.add_file("sashARCS", 2, 512).unwrap();
+        let off = VD_OFFSET;
+        assert_eq!(&vh.as_bytes()[off..off + 8], b"sashARCS", "name must fill all 8 bytes");
+        assert_eq!(vh.files()[0].name, "sashARCS");
+        assert_eq!(vh.files()[0].lbn, 2, "lbn must start at byte 8, not after a NUL");
+    }
+
+    #[test]
+    fn checksum_stays_valid_after_every_mutation() {
+        let mut vh = VolumeHeader::new();
+        assert!(vh.csum_valid());
+        vh.set_bootfile("cputest").unwrap();
+        assert!(vh.csum_valid());
+        vh.add_file("cputest", 8, 4096).unwrap();
+        assert!(vh.csum_valid());
+        vh.set_partition(7, 100, 8, PT_RAW).unwrap();
+        assert!(vh.csum_valid());
+    }
+
+    #[test]
+    fn rejects_bad_names_and_a_full_directory() {
+        let mut vh = VolumeHeader::new();
+        assert!(vh.add_file("toolongname", 0, 0).is_err(), "9+ char name must be rejected");
+        assert!(vh.add_file("", 0, 0).is_err(), "empty name must be rejected");
+        for i in 0..VD_MAX_ENTRIES {
+            vh.add_file(&format!("f{}", i), i as u32, 1).unwrap();
+        }
+        assert!(vh.add_file("onemore", 0, 1).is_err(), "16th entry must be rejected");
+        assert_eq!(vh.files().len(), VD_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn from_bytes_rejects_non_sgi_media() {
+        assert!(VolumeHeader::from_bytes(&[0u8; 512]).is_err(), "no magic");
+        assert!(VolumeHeader::from_bytes(&[0u8; 16]).is_err(), "short read");
+    }
+
+    #[test]
+    fn build_image_places_files_and_partitions() {
+        let p = unique_tmp_path("build");
+        let payload = unique_tmp_path("payload");
+        std::fs::write(&payload, vec![0xAAu8; 600]).unwrap();
+
+        let spec = ImageSpec {
+            total_bytes: 1024 * 1024,
+            bootfile: None,
+            files: vec![("cputest".into(), payload.clone())],
+            partitions: vec![PartitionSpec { slot: 7, first_block: 64, nblks: 128, ptype: PT_RAW, content: None }],
+        };
+        let placed = build_image(&p, &spec).expect("build");
+        assert_eq!(placed.len(), 1);
+        assert_eq!(placed[0].nbytes, 600);
+        assert_eq!(placed[0].lbn, VH_SECTORS as u32, "first file lands right after the VH region");
+
+        let bytes = std::fs::read(&p).unwrap();
+        assert_eq!(bytes.len(), 1024 * 1024);
+        let vh = VolumeHeader::from_bytes(&bytes).unwrap();
+        assert!(vh.csum_valid());
+        assert_eq!(vh.bootfile(), "cputest", "bootfile defaults to the first file");
+        assert_eq!(vh.files(), placed);
+
+        // File contents must be readable at lbn * 512, exactly nbytes long.
+        let off = placed[0].lbn as usize * SECTOR_SIZE as usize;
+        assert_eq!(&bytes[off..off + 600], &vec![0xAAu8; 600][..]);
+
+        let parts = vh.partitions();
+        assert!(parts.iter().any(|e| e.slot == 7 && e.first_block == 64 && e.nblks == 128));
+        assert!(parts.iter().any(|e| e.slot == 8 && e.ptype == PT_VOLHDR), "slot 8 auto-added");
+        assert!(parts.iter().any(|e| e.slot == 10 && e.nblks == 2048), "slot 10 covers the disk");
+
+        let _ = std::fs::remove_file(&p);
+        let _ = std::fs::remove_file(&payload);
+    }
+
+    #[test]
+    fn build_image_rejects_an_image_too_small_for_its_contents() {
+        let p = unique_tmp_path("toosmall");
+        let payload = unique_tmp_path("toosmall-payload");
+        std::fs::write(&payload, vec![0u8; 4096]).unwrap();
+        let spec = ImageSpec {
+            total_bytes: 4096,
+            files: vec![("cputest".into(), payload.clone())],
+            ..Default::default()
+        };
+        assert!(build_image(&p, &spec).is_err());
+        let _ = std::fs::remove_file(&p);
+        let _ = std::fs::remove_file(&payload);
     }
 }

--- a/src/testdev.rs
+++ b/src/testdev.rs
@@ -1,0 +1,359 @@
+//! Bare-metal test device: guest console, machine-state dump, process exit code.
+//!
+//! Default-off (`--test-device`). It exists so a self-checking bare-metal test
+//! binary can report to the host without the SCC: a byte at a time to stdout, a
+//! full machine-state dump to a JSON file, and a real process exit code instead
+//! of a serial string CI has to match.
+//!
+//! **Address**: GIO64 expansion slot 0 (`0x1F400000`, 64 KB of the 2 MB
+//! aperture). An Indy has one GIO64 expansion connector and a stock machine
+//! ships with nothing in it, so IRIS routes the whole slot to the GIO bus-error
+//! (timeout) handler — the device replaces "nothing answers here" with itself
+//! and displaces no real hardware. It cannot collide with the IP22/IP24 map:
+//! graphics live in the *graphics* slot at 0x1F000000, the second Newport head
+//! and IMPACT/MGRAS take expansion slot 1 at 0x1F600000, the MC is at
+//! 0x1FA00000, HPC3 at 0x1FB80000 and the PROM at 0x1FC00000. The one thing
+//! that does claim this slot is the `ultra64` dev board, which is why enabling
+//! both is refused.
+//!
+//! The guest detects the device by reading `SIGNATURE`; on real hardware the
+//! empty slot times out, so a suite falls back to SCC-only output.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::mips_core::MipsCore;
+use crate::traits::{BusDevice, BusRead32, BusRead8, Device, Resettable, Saveable, BUS_OK};
+
+/// GIO64 expansion slot 0. 64 KB is decoded; registers repeat every 16 bytes.
+pub const TEST_DEV_BASE: u32 = 0x1F400000;
+pub const TEST_DEV_SIZE: u32 = 0x0001_0000;
+
+pub const REG_SIGNATURE: u32 = 0x00;
+pub const REG_PUTC: u32 = 0x04;
+pub const REG_DUMP: u32 = 0x08;
+pub const REG_EXIT: u32 = 0x0C;
+
+/// Reads back at `REG_SIGNATURE` — "IRIS" in ASCII.
+pub const SIGNATURE: u32 = 0x4952_4953;
+
+/// Where `REG_DUMP` writes go when no path is configured.
+pub const DEFAULT_DUMP_PATH: &str = "iris-testdev-dump.json";
+
+pub struct TestDevice {
+    /// Dump file path. Never defaults to a bare CWD-relative name in a
+    /// sandboxed app, where the CWD is `/` and unwritable — the caller passes
+    /// an absolute path there.
+    dump_path: std::path::PathBuf,
+    /// Set by `attach_core`. Only read from the CPU thread, which is the thread
+    /// that issues the store that lands here, so there is no race — the same
+    /// process-lifetime argument as `MipsCpu`'s `cycles_ptr`/`interrupts_ptr`.
+    core: Mutex<Option<CorePtr>>,
+    dumps: AtomicU32,
+    last_tag: AtomicU64,
+    chars: AtomicU64,
+    running: AtomicBool,
+}
+
+/// Raw pointer to the executor's `MipsCore`, valid for the process lifetime.
+struct CorePtr(*const MipsCore);
+// SAFETY: the pointee outlives the device and is only dereferenced from the CPU
+// thread while that thread is inside its own store instruction.
+unsafe impl Send for CorePtr {}
+unsafe impl Sync for CorePtr {}
+
+impl TestDevice {
+    pub fn new(dump_path: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            dump_path: dump_path.into(),
+            core: Mutex::new(None),
+            dumps: AtomicU32::new(0),
+            last_tag: AtomicU64::new(0),
+            chars: AtomicU64::new(0),
+            running: AtomicBool::new(false),
+        }
+    }
+
+    /// Point the device at the CPU state it dumps. Called once at wiring time.
+    pub fn attach_core(&self, core: *const MipsCore) {
+        *self.core.lock() = Some(CorePtr(core));
+    }
+
+    pub fn dump_path(&self) -> &std::path::Path {
+        &self.dump_path
+    }
+
+    pub fn dumps_written(&self) -> u32 {
+        self.dumps.load(Ordering::Relaxed)
+    }
+
+    fn putc(&self, byte: u8) {
+        let mut out = std::io::stdout().lock();
+        let _ = out.write_all(&[byte]);
+        // Flush per line so a hung test still shows everything it printed.
+        if byte == b'\n' {
+            let _ = out.flush();
+        }
+        self.chars.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Write the full machine state as JSON. `tag` distinguishes dump points, so
+    /// a test can dump more than once; the file is overwritten each time.
+    fn dump(&self, tag: u32) {
+        self.last_tag.store(tag as u64, Ordering::Relaxed);
+        let guard = self.core.lock();
+        let Some(CorePtr(ptr)) = guard.as_ref() else {
+            eprintln!("test device: DUMP with no CPU attached");
+            return;
+        };
+        // SAFETY: see CorePtr — the CPU thread is the one storing to this register.
+        let core = unsafe { &**ptr };
+        let json = dump_json(core, tag);
+        drop(guard);
+
+        match std::fs::write(&self.dump_path, json) {
+            Ok(()) => {
+                self.dumps.fetch_add(1, Ordering::Relaxed);
+                eprintln!("test device: dump {} → {}", tag, self.dump_path.display());
+            }
+            Err(e) => eprintln!("test device: dump {} to {}: {}", tag, self.dump_path.display(), e),
+        }
+    }
+
+    /// Terminate the emulator with the guest's exit code. Stdout is flushed
+    /// first so buffered `PUTC` output is never lost.
+    fn exit(&self, code: u32) -> ! {
+        let _ = std::io::stdout().flush();
+        eprintln!("test device: guest requested exit({})", code as u8);
+        std::process::exit(code as u8 as i32)
+    }
+}
+
+/// Full architectural state as JSON: GPRs, HI/LO, PC, CP0 by name, FPRs + FCSR/FIR.
+pub fn dump_json(core: &MipsCore, tag: u32) -> String {
+    let hex64 = |v: u64| format!("\"{:#018x}\"", v);
+    let hex32 = |v: u32| format!("\"{:#010x}\"", v);
+    let list = |vals: &[u64]| {
+        vals.iter().map(|v| hex64(*v)).collect::<Vec<_>>().join(", ")
+    };
+
+    // PRId imp field: 0x04 = R4000/R4400, 0x23 = R5000.
+    let cpu = match (core.cp0_prid >> 8) & 0xFF {
+        0x04 => "R4400",
+        0x23 => "R5000",
+        _ => "unknown",
+    };
+
+    let mut s = String::with_capacity(4096);
+    s.push_str("{\n");
+    s.push_str(&format!("  \"tag\": {},\n", tag));
+    s.push_str(&format!("  \"cpu\": \"{}\",\n", cpu));
+    s.push_str(&format!("  \"pc\": {},\n", hex64(core.pc)));
+    s.push_str(&format!("  \"hi\": {},\n", hex64(core.hi)));
+    s.push_str(&format!("  \"lo\": {},\n", hex64(core.lo)));
+    s.push_str(&format!("  \"gpr\": [{}],\n", list(&core.gpr)));
+    s.push_str(&format!("  \"fpr\": [{}],\n", list(&core.fpr)));
+    s.push_str(&format!("  \"fcsr\": {},\n", hex32(core.fpu_fcsr)));
+    s.push_str(&format!("  \"fir\": {},\n", hex32(core.fpu_fir)));
+    s.push_str("  \"cp0\": {\n");
+    let cp0: [(&str, String); 24] = [
+        ("Index",    hex32(core.cp0_index)),
+        ("Random",   hex32(core.cp0_random)),
+        ("EntryLo0", hex64(core.cp0_entrylo0)),
+        ("EntryLo1", hex64(core.cp0_entrylo1)),
+        ("Context",  hex64(core.cp0_context)),
+        ("PageMask", hex64(core.cp0_pagemask)),
+        ("Wired",    hex32(core.cp0_wired)),
+        ("BadVAddr", hex64(core.cp0_badvaddr)),
+        ("Count",    hex64(core.cp0_count)),
+        ("EntryHi",  hex64(core.cp0_entryhi)),
+        ("Compare",  hex64(core.cp0_compare)),
+        ("Status",   hex32(core.cp0_status)),
+        ("Cause",    hex32(core.cp0_cause)),
+        ("EPC",      hex64(core.cp0_epc)),
+        ("PRId",     hex32(core.cp0_prid)),
+        ("Config",   hex32(core.cp0_config)),
+        ("LLAddr",   hex32(core.cp0_lladdr)),
+        ("WatchLo",  hex32(core.cp0_watchlo)),
+        ("WatchHi",  hex32(core.cp0_watchhi)),
+        ("XContext", hex64(core.cp0_xcontext)),
+        ("ECC",      hex32(core.cp0_ecc)),
+        ("CacheErr", hex32(core.cp0_cacheerr)),
+        ("TagLo",    hex32(core.cp0_taglo)),
+        ("TagHi",    hex32(core.cp0_taghi)),
+    ];
+    let body: Vec<String> = cp0.iter().map(|(n, v)| format!("    \"{}\": {}", n, v)).collect();
+    s.push_str(&body.join(",\n"));
+    s.push_str("\n  }\n}\n");
+    s
+}
+
+impl BusDevice for TestDevice {
+    fn read32(&self, addr: u32) -> BusRead32 {
+        match (addr - TEST_DEV_BASE) & 0xF {
+            REG_SIGNATURE => BusRead32::ok(SIGNATURE),
+            _ => BusRead32::ok(0),
+        }
+    }
+
+    fn write32(&self, addr: u32, val: u32) -> u32 {
+        match (addr - TEST_DEV_BASE) & 0xF {
+            REG_PUTC => self.putc(val as u8),
+            REG_DUMP => self.dump(val),
+            REG_EXIT => self.exit(val),
+            _ => {}
+        }
+        BUS_OK
+    }
+
+    fn read8(&self, addr: u32) -> BusRead8 {
+        // Byte reads of SIGNATURE, big-endian: byte 0 is the high byte.
+        let off = (addr - TEST_DEV_BASE) & 0xF;
+        if off < 4 {
+            return BusRead8::ok((SIGNATURE >> (8 * (3 - off))) as u8);
+        }
+        BusRead8::ok(0)
+    }
+
+    fn write8(&self, addr: u32, val: u8) -> u32 {
+        // A byte store to any lane of a register acts on that register, so
+        // `sb` to PUTC works without the guest building a whole word.
+        match (addr - TEST_DEV_BASE) & 0xC {
+            REG_PUTC => self.putc(val),
+            REG_DUMP => self.dump(val as u32),
+            REG_EXIT => self.exit(val as u32),
+            _ => {}
+        }
+        BUS_OK
+    }
+}
+
+impl Device for TestDevice {
+    fn step(&self, _cycles: u64) {}
+    fn stop(&self) { self.running.store(false, Ordering::Relaxed); }
+    fn start(&self) { self.running.store(true, Ordering::Relaxed); }
+    fn is_running(&self) -> bool { self.running.load(Ordering::Relaxed) }
+    fn get_clock(&self) -> u64 { 0 }
+
+    fn register_commands(&self) -> Vec<(String, String)> {
+        vec![("testdev".to_string(), "Test device status: testdev".to_string())]
+    }
+
+    fn execute_command(&self, cmd: &str, _args: &[&str], mut writer: Box<dyn Write + Send>) -> Result<(), String> {
+        if cmd != "testdev" {
+            return Err("Command not found".to_string());
+        }
+        writeln!(writer, "test device @ {:#010x}  signature {:#010x}", TEST_DEV_BASE, SIGNATURE).unwrap();
+        writeln!(writer, "  dump file : {}", self.dump_path.display()).unwrap();
+        writeln!(writer, "  dumps     : {}  (last tag {})",
+                 self.dumps.load(Ordering::Relaxed), self.last_tag.load(Ordering::Relaxed)).unwrap();
+        writeln!(writer, "  chars out : {}", self.chars.load(Ordering::Relaxed)).unwrap();
+        Ok(())
+    }
+}
+
+impl Resettable for TestDevice {
+    fn power_on(&self) {
+        self.dumps.store(0, Ordering::Relaxed);
+        self.last_tag.store(0, Ordering::Relaxed);
+        self.chars.store(0, Ordering::Relaxed);
+    }
+}
+
+impl Saveable for TestDevice {
+    fn save_state(&self) -> toml::Value {
+        let mut t = toml::value::Table::new();
+        t.insert("dumps".into(), toml::Value::Integer(self.dumps.load(Ordering::Relaxed) as i64));
+        t.insert("last_tag".into(), toml::Value::Integer(self.last_tag.load(Ordering::Relaxed) as i64));
+        t.insert("chars".into(), toml::Value::Integer(self.chars.load(Ordering::Relaxed) as i64));
+        toml::Value::Table(t)
+    }
+
+    fn load_state(&self, v: &toml::Value) -> Result<(), String> {
+        let get = |k: &str| v.get(k).and_then(|x| x.as_integer()).unwrap_or(0);
+        self.dumps.store(get("dumps") as u32, Ordering::Relaxed);
+        self.last_tag.store(get("last_tag") as u64, Ordering::Relaxed);
+        self.chars.store(get("chars") as u64, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signature_reads_back_word_and_byte_wise() {
+        let d = TestDevice::new("unused");
+        assert_eq!(d.read32(TEST_DEV_BASE).data, SIGNATURE);
+        // Repeats every 16 bytes across the decoded window.
+        assert_eq!(d.read32(TEST_DEV_BASE + 0x10).data, SIGNATURE);
+        let bytes: Vec<u8> = (0..4).map(|i| d.read8(TEST_DEV_BASE + i).data).collect();
+        assert_eq!(&bytes, b"IRIS", "signature is big-endian ASCII");
+    }
+
+    #[test]
+    fn dump_json_covers_the_whole_architectural_state() {
+        let mut core = MipsCore::new();
+        core.pc = 0xFFFF_FFFF_8810_0000;
+        core.gpr[31] = 0xDEAD_BEEF;
+        core.hi = 1;
+        core.lo = 2;
+        core.fpr[7] = 0x4000_0000_0000_0000;
+        core.fpu_fcsr = 0x0080_0000;
+        core.cp0_status = 0x3400_0000;
+        core.cp0_epc = 0x8810_0004;
+
+        let j = dump_json(&core, 42);
+        assert!(j.contains("\"tag\": 42"));
+        assert!(j.contains("\"pc\": \"0xffffffff88100000\""));
+        assert!(j.contains("\"hi\": \"0x0000000000000001\""));
+        assert!(j.contains("0x00000000deadbeef"), "gpr[31] must be present");
+        assert!(j.contains("0x4000000000000000"), "fpr[7] must be present");
+        assert!(j.contains("\"fcsr\": \"0x00800000\""));
+        assert_eq!(j.matches("0x").count() >= 32 + 32, true, "all 64 registers present");
+        for reg in ["Status", "Cause", "EPC", "BadVAddr", "Config", "PRId", "EntryHi", "EntryLo0",
+                    "EntryLo1", "PageMask", "Index", "Random", "Wired", "Context", "XContext",
+                    "Count", "Compare", "WatchLo", "WatchHi", "LLAddr", "TagLo", "TagHi"] {
+            assert!(j.contains(&format!("\"{}\"", reg)), "cp0 {} missing", reg);
+        }
+        // The R4400/R5000 identification comes from PRId, not a build flag.
+        assert!(j.contains("\"cpu\": \"R4400\"") || j.contains("\"cpu\": \"R5000\""));
+    }
+
+    #[test]
+    fn dump_writes_a_file_and_counts() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+        let path = std::env::temp_dir().join(format!("iris-testdev-{}.json", nanos));
+        let core = MipsCore::new();
+        let d = TestDevice::new(&path);
+        d.attach_core(&core as *const MipsCore);
+
+        d.write32(TEST_DEV_BASE + REG_DUMP, 7);
+        assert_eq!(d.dumps_written(), 1);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("\"tag\": 7"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_load_round_trip() {
+        let core = MipsCore::new();
+        let a = TestDevice::new("unused");
+        a.attach_core(&core as *const MipsCore);
+        a.write32(TEST_DEV_BASE + REG_PUTC, b'x' as u32);
+        a.last_tag.store(3, Ordering::Relaxed);
+        a.dumps.store(2, Ordering::Relaxed);
+
+        let saved = a.save_state();
+        let b = TestDevice::new("unused");
+        b.load_state(&saved).unwrap();
+        assert_eq!(b.save_state(), saved, "save → load → save must round-trip");
+
+        b.power_on();
+        assert_eq!(b.dumps_written(), 0, "power_on clears counters");
+    }
+}

--- a/src/testdev.rs
+++ b/src/testdev.rs
@@ -16,6 +16,10 @@
 //! that does claim this slot is the `ultra64` dev board, which is why enabling
 //! both is refused.
 //!
+//! The PROM's own slot-0 probe was measured at physical `0x1F46A07C`, outside
+//! the 64 KB this device decodes, so POST still sees a GIO timeout there even
+//! with the device enabled.
+//!
 //! The guest detects the device by reading `SIGNATURE`; on real hardware the
 //! empty slot times out, so a suite falls back to SCC-only output.
 

--- a/src/tftp.rs
+++ b/src/tftp.rs
@@ -1,0 +1,454 @@
+//! Read-only RFC 1350 TFTP server for PROM network boot (`boot -f bootp()<file>`).
+//!
+//! Pure protocol: packets in, packets out, no sockets. The NAT gateway
+//! (`net.rs`, next to `handle_bootp`) drives it and injects the replies, so
+//! nothing here touches the host network — the same shape as `nfsudp.rs`.
+//!
+//! Read-only by construction: WRQ is refused and no path ever opens for writing.
+//! Packet fields are network byte order, which is the Edge, so swapping is correct.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::net::Ipv4Addr;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub const BLOCK_SIZE: usize = 512;
+/// Give up on a transfer after this many unanswered retransmits of one block.
+pub const MAX_RETRIES: u8 = 5;
+pub const RETRANSMIT_TIMEOUT: Duration = Duration::from_millis(1000);
+
+const OP_RRQ: u16 = 1;
+const OP_WRQ: u16 = 2;
+const OP_DATA: u16 = 3;
+const OP_ACK: u16 = 4;
+const OP_ERROR: u16 = 5;
+
+/// RFC 1350 error codes, only the ones a read-only server can raise.
+const ERR_NOT_DEFINED: u16 = 0;
+const ERR_FILE_NOT_FOUND: u16 = 1;
+const ERR_ACCESS_VIOLATION: u16 = 2;
+const ERR_ILLEGAL_OP: u16 = 4;
+const ERR_UNKNOWN_ID: u16 = 5;
+
+/// A client is identified by its address and source port (its TID).
+pub type ClientId = (Ipv4Addr, u16);
+
+struct Transfer {
+    file: File,
+    /// Block number of the DATA packet currently outstanding (1-based, wraps).
+    block: u16,
+    /// File offset of that block.
+    offset: u64,
+    /// The packet itself, kept so a retransmit is a resend, not a re-read.
+    last_packet: Vec<u8>,
+    /// True once the outstanding block was short — its ACK ends the transfer.
+    final_block: bool,
+    retries: u8,
+    sent_at: Instant,
+}
+
+pub struct TftpServer {
+    root: PathBuf,
+    transfers: HashMap<ClientId, Transfer>,
+    timeout: Duration,
+}
+
+impl TftpServer {
+    /// Serve read-only out of `root`. Nothing outside it is ever reachable.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root, transfers: HashMap::new(), timeout: RETRANSMIT_TIMEOUT }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Handle one datagram from `client`, returning the packet to send back.
+    pub fn handle(&mut self, client: ClientId, packet: &[u8], now: Instant) -> Option<Vec<u8>> {
+        if packet.len() < 4 {
+            return None;
+        }
+        match u16::from_be_bytes([packet[0], packet[1]]) {
+            OP_RRQ => Some(self.start_read(client, &packet[2..], now)),
+            OP_WRQ => Some(error_packet(ERR_ACCESS_VIOLATION, "server is read-only")),
+            OP_ACK => self.handle_ack(client, u16::from_be_bytes([packet[2], packet[3]]), now),
+            OP_ERROR => {
+                self.transfers.remove(&client);
+                None
+            }
+            _ => Some(error_packet(ERR_ILLEGAL_OP, "only RRQ is supported")),
+        }
+    }
+
+    /// Retransmit any DATA that has gone unanswered, and drop transfers that
+    /// have exhausted their retries. Returns the packets to send.
+    pub fn tick(&mut self, now: Instant) -> Vec<(ClientId, Vec<u8>)> {
+        let timeout = self.timeout;
+        let mut out = Vec::new();
+        self.transfers.retain(|client, t| {
+            if now.duration_since(t.sent_at) < timeout {
+                return true;
+            }
+            if t.retries >= MAX_RETRIES {
+                return false;
+            }
+            t.retries += 1;
+            t.sent_at = now;
+            out.push((*client, t.last_packet.clone()));
+            true
+        });
+        out
+    }
+
+    pub fn active_transfers(&self) -> usize {
+        self.transfers.len()
+    }
+
+    /// Whether `client` still has a transfer in flight. The NAT uses this to
+    /// drop the client bookkeeping it keeps alongside.
+    pub fn has_transfer(&self, client: &ClientId) -> bool {
+        self.transfers.contains_key(client)
+    }
+
+    fn start_read(&mut self, client: ClientId, body: &[u8], now: Instant) -> Vec<u8> {
+        let Some((name, mode)) = parse_request(body) else {
+            return error_packet(ERR_NOT_DEFINED, "malformed request");
+        };
+        // The PROM only ever asks for octet (verified in the embedded PROM image);
+        // netascii would need CRLF translation we deliberately don't do.
+        if !mode.eq_ignore_ascii_case("octet") {
+            return error_packet(ERR_NOT_DEFINED, "only octet mode is supported");
+        }
+        let Some(path) = self.resolve(&name) else {
+            return error_packet(ERR_FILE_NOT_FOUND, &format!("{}: not found", name));
+        };
+        let file = match File::open(&path) {
+            Ok(f) => f,
+            Err(e) => return error_packet(ERR_FILE_NOT_FOUND, &format!("{}: {}", name, e)),
+        };
+
+        // A second RRQ from the same TID replaces whatever was in flight.
+        let mut t = Transfer {
+            file,
+            block: 0,
+            offset: 0,
+            last_packet: Vec::new(),
+            final_block: false,
+            retries: 0,
+            sent_at: now,
+        };
+        match send_block(&mut t, 1, 0, now) {
+            Ok(pkt) => {
+                self.transfers.insert(client, t);
+                pkt
+            }
+            Err(e) => error_packet(ERR_NOT_DEFINED, &format!("{}: {}", name, e)),
+        }
+    }
+
+    fn handle_ack(&mut self, client: ClientId, block: u16, now: Instant) -> Option<Vec<u8>> {
+        let Some(t) = self.transfers.get_mut(&client) else {
+            return Some(error_packet(ERR_UNKNOWN_ID, "no transfer in progress"));
+        };
+        // A duplicate ACK (the classic Sorcerer's Apprentice case) must not
+        // advance the transfer — ignore anything that isn't the block in flight.
+        if block != t.block {
+            return None;
+        }
+        if t.final_block {
+            self.transfers.remove(&client);
+            return None;
+        }
+        let next_offset = t.offset + BLOCK_SIZE as u64;
+        // Block numbers wrap 65535 → 0; a file can be longer than 32 MB.
+        let next_block = t.block.wrapping_add(1);
+        match send_block(t, next_block, next_offset, now) {
+            Ok(pkt) => Some(pkt),
+            Err(e) => {
+                self.transfers.remove(&client);
+                Some(error_packet(ERR_NOT_DEFINED, &e.to_string()))
+            }
+        }
+    }
+
+    /// Resolve `name` under the root, refusing anything that escapes it:
+    /// absolute paths, any `..`, and symlinks pointing outside.
+    fn resolve(&self, name: &str) -> Option<PathBuf> {
+        let rel = Path::new(name);
+        if rel.as_os_str().is_empty() || rel.is_absolute() {
+            return None;
+        }
+        if !rel.components().all(|c| matches!(c, Component::Normal(_))) {
+            return None;
+        }
+        let root = self.root.canonicalize().ok()?;
+        let full = root.join(rel).canonicalize().ok()?;
+        full.starts_with(&root).then_some(full)
+    }
+}
+
+/// Read `block` at `offset` and build its DATA packet, recording it for retransmit.
+fn send_block(t: &mut Transfer, block: u16, offset: u64, now: Instant) -> std::io::Result<Vec<u8>> {
+    let mut buf = [0u8; BLOCK_SIZE];
+    t.file.seek(SeekFrom::Start(offset))?;
+    let mut filled = 0;
+    while filled < BLOCK_SIZE {
+        match t.file.read(&mut buf[filled..])? {
+            0 => break,
+            n => filled += n,
+        }
+    }
+
+    let mut pkt = Vec::with_capacity(4 + filled);
+    pkt.extend_from_slice(&OP_DATA.to_be_bytes());
+    pkt.extend_from_slice(&block.to_be_bytes());
+    pkt.extend_from_slice(&buf[..filled]);
+
+    t.block = block;
+    t.offset = offset;
+    // A short block ends the transfer — including the zero-length one that
+    // follows a file whose length is an exact multiple of 512.
+    t.final_block = filled < BLOCK_SIZE;
+    t.last_packet = pkt.clone();
+    t.retries = 0;
+    t.sent_at = now;
+    Ok(pkt)
+}
+
+fn error_packet(code: u16, msg: &str) -> Vec<u8> {
+    let mut pkt = Vec::with_capacity(5 + msg.len());
+    pkt.extend_from_slice(&OP_ERROR.to_be_bytes());
+    pkt.extend_from_slice(&code.to_be_bytes());
+    pkt.extend_from_slice(msg.as_bytes());
+    pkt.push(0);
+    pkt
+}
+
+/// Split an RRQ/WRQ body into its NUL-terminated filename and mode.
+fn parse_request(body: &[u8]) -> Option<(String, String)> {
+    let mut parts = body.split(|&b| b == 0);
+    let name = String::from_utf8(parts.next()?.to_vec()).ok()?;
+    let mode = String::from_utf8(parts.next()?.to_vec()).ok()?;
+    Some((name, mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CLIENT: ClientId = (Ipv4Addr::new(192, 168, 0, 2), 1069);
+
+    fn tmp_root(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let d = std::env::temp_dir().join(format!("iris-tftp-{}-{}", tag, nanos));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn rrq(name: &str, mode: &str) -> Vec<u8> {
+        let mut p = vec![0, 1];
+        p.extend_from_slice(name.as_bytes());
+        p.push(0);
+        p.extend_from_slice(mode.as_bytes());
+        p.push(0);
+        p
+    }
+
+    fn ack(block: u16) -> Vec<u8> {
+        let mut p = vec![0, 4];
+        p.extend_from_slice(&block.to_be_bytes());
+        p
+    }
+
+    fn opcode(p: &[u8]) -> u16 { u16::from_be_bytes([p[0], p[1]]) }
+    fn field(p: &[u8]) -> u16 { u16::from_be_bytes([p[2], p[3]]) }
+
+    /// Run a whole transfer, returning the reassembled file and the block count.
+    fn transfer(srv: &mut TftpServer, name: &str) -> (Vec<u8>, usize) {
+        let now = Instant::now();
+        let mut got = Vec::new();
+        let mut pkt = srv.handle(CLIENT, &rrq(name, "octet"), now).unwrap();
+        let mut blocks = 0;
+        loop {
+            assert_eq!(opcode(&pkt), OP_DATA, "expected DATA, got {:?}", &pkt[..4.min(pkt.len())]);
+            blocks += 1;
+            got.extend_from_slice(&pkt[4..]);
+            let last = pkt.len() - 4 < BLOCK_SIZE;
+            match srv.handle(CLIENT, &ack(field(&pkt)), now) {
+                Some(next) => pkt = next,
+                None => {
+                    assert!(last, "transfer ended on a full block");
+                    break;
+                }
+            }
+        }
+        (got, blocks)
+    }
+
+    #[test]
+    fn serves_a_file_that_is_not_a_multiple_of_512() {
+        let root = tmp_root("short");
+        let data: Vec<u8> = (0..1000u32).map(|i| i as u8).collect();
+        std::fs::write(root.join("cputest"), &data).unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let (got, blocks) = transfer(&mut srv, "cputest");
+        assert_eq!(got, data);
+        assert_eq!(blocks, 2, "1000 bytes = 512 + 488");
+        assert_eq!(srv.active_transfers(), 0, "transfer must be cleaned up");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn exact_multiple_of_512_ends_with_a_zero_length_block() {
+        let root = tmp_root("exact");
+        let data = vec![0xA5u8; 1024];
+        std::fs::write(root.join("aligned"), &data).unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let (got, blocks) = transfer(&mut srv, "aligned");
+        assert_eq!(got, data);
+        assert_eq!(blocks, 3, "1024 bytes = 512 + 512 + a final empty block");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn empty_file_is_one_empty_block() {
+        let root = tmp_root("empty");
+        std::fs::write(root.join("nothing"), b"").unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let (got, blocks) = transfer(&mut srv, "nothing");
+        assert!(got.is_empty());
+        assert_eq!(blocks, 1);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn duplicate_ack_does_not_advance_the_transfer() {
+        let root = tmp_root("dup");
+        std::fs::write(root.join("f"), vec![7u8; 2000]).unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let now = Instant::now();
+        srv.handle(CLIENT, &rrq("f", "octet"), now).unwrap();
+        let b2 = srv.handle(CLIENT, &ack(1), now).unwrap();
+        assert_eq!(field(&b2), 2);
+        assert!(srv.handle(CLIENT, &ack(1), now).is_none(), "stale ACK must be ignored");
+        let b3 = srv.handle(CLIENT, &ack(2), now).unwrap();
+        assert_eq!(field(&b3), 3, "transfer resumes from the block actually in flight");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn retransmits_then_gives_up() {
+        let root = tmp_root("rtx");
+        std::fs::write(root.join("f"), vec![1u8; 2000]).unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let start = Instant::now();
+        let first = srv.handle(CLIENT, &rrq("f", "octet"), start).unwrap();
+
+        let mut now = start;
+        for i in 1..=MAX_RETRIES {
+            now += RETRANSMIT_TIMEOUT;
+            let out = srv.tick(now);
+            assert_eq!(out.len(), 1, "retry {} should resend", i);
+            assert_eq!(out[0].1, first, "retransmit must resend the same DATA");
+        }
+        now += RETRANSMIT_TIMEOUT;
+        assert!(srv.tick(now).is_empty(), "transfer is dropped after MAX_RETRIES");
+        assert_eq!(srv.active_transfers(), 0);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn tick_is_quiet_before_the_timeout() {
+        let root = tmp_root("quiet");
+        std::fs::write(root.join("f"), vec![1u8; 2000]).unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let start = Instant::now();
+        srv.handle(CLIENT, &rrq("f", "octet"), start).unwrap();
+        assert!(srv.tick(start + Duration::from_millis(10)).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn missing_file_is_error_1() {
+        let root = tmp_root("missing");
+        let mut srv = TftpServer::new(root.clone());
+        let p = srv.handle(CLIENT, &rrq("nope", "octet"), Instant::now()).unwrap();
+        assert_eq!(opcode(&p), OP_ERROR);
+        assert_eq!(field(&p), ERR_FILE_NOT_FOUND);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn write_request_is_refused() {
+        let root = tmp_root("wrq");
+        let mut srv = TftpServer::new(root.clone());
+        let mut p = vec![0, 2];
+        p.extend_from_slice(b"evil\0octet\0");
+        let r = srv.handle(CLIENT, &p, Instant::now()).unwrap();
+        assert_eq!(opcode(&r), OP_ERROR);
+        assert_eq!(field(&r), ERR_ACCESS_VIOLATION);
+        assert!(!root.join("evil").exists(), "WRQ must never create a file");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn netascii_is_refused() {
+        let root = tmp_root("mode");
+        std::fs::write(root.join("f"), b"x").unwrap();
+        let mut srv = TftpServer::new(root.clone());
+        let p = srv.handle(CLIENT, &rrq("f", "netascii"), Instant::now()).unwrap();
+        assert_eq!(opcode(&p), OP_ERROR);
+        // Case-insensitive: the PROM sends lowercase "octet", others vary.
+        let ok = srv.handle(CLIENT, &rrq("f", "OCTET"), Instant::now()).unwrap();
+        assert_eq!(opcode(&ok), OP_DATA);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn refuses_paths_that_escape_the_root() {
+        let root = tmp_root("escape");
+        let outside = root.parent().unwrap().join(format!(
+            "iris-tftp-outside-{}",
+            root.file_name().unwrap().to_string_lossy()
+        ));
+        std::fs::write(&outside, b"secret").unwrap();
+        std::fs::write(root.join("inside"), b"fine").unwrap();
+        let mut srv = TftpServer::new(root.clone());
+
+        let now = Instant::now();
+        for bad in ["../etc/passwd", "/etc/passwd", "sub/../../escape", ""] {
+            let p = srv.handle(CLIENT, &rrq(bad, "octet"), now).unwrap();
+            assert_eq!(opcode(&p), OP_ERROR, "{} must be refused", bad);
+        }
+
+        // A symlink pointing out of the root is refused even though it resolves.
+        #[cfg(unix)]
+        {
+            let link = root.join("link");
+            std::os::unix::fs::symlink(&outside, &link).unwrap();
+            let p = srv.handle(CLIENT, &rrq("link", "octet"), now).unwrap();
+            assert_eq!(opcode(&p), OP_ERROR, "symlink out of the root must be refused");
+        }
+
+        let good = srv.handle(CLIENT, &rrq("inside", "octet"), now).unwrap();
+        assert_eq!(opcode(&good), OP_DATA);
+
+        let _ = std::fs::remove_file(&outside);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ack_without_a_transfer_is_error_5() {
+        let root = tmp_root("stray");
+        let mut srv = TftpServer::new(root.clone());
+        let p = srv.handle(CLIENT, &ack(1), Instant::now()).unwrap();
+        assert_eq!(opcode(&p), OP_ERROR);
+        assert_eq!(field(&p), ERR_UNKNOWN_ID);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src/wd33c93a.rs
+++ b/src/wd33c93a.rs
@@ -612,15 +612,17 @@ impl Wd33c93a {
         state.devices.iter().flatten().filter(|d| d.pending_chd_sync().is_some()).count()
     }
 
-    /// Fold every pending CHD diff back into its base ("sync"), preserving the
-    /// base's compression. Releases each disk backend first (closing the CHD),
-    /// then rebuilds outside the device lock since recompression is slow.
+    /// Fold pending CHD diffs back into their bases ("sync"), preserving the
+    /// base's compression. `only` limits it to one SCSI id; `None` means all.
+    /// Releases each disk backend first (closing the CHD), then rebuilds
+    /// outside the device lock since recompression is slow.
     /// `progress(done, total, fraction)` reports per-disk progress; `cancel()`
     /// stops before the next disk (the in-flight rebuild also honours it),
     /// leaving every un-synced base+diff intact. Returns the count synced.
     #[cfg(feature = "chd")]
     pub fn sync_chd_disks(
         &self,
+        only: Option<usize>,
         progress: &mut dyn FnMut(usize, usize, f32),
         cancel: &dyn Fn() -> bool,
     ) -> std::io::Result<usize> {
@@ -631,6 +633,7 @@ impl Wd33c93a {
             let mut state = self.state.lock();
             let mut v = Vec::new();
             for id in 0..8 {
+                if only.is_some_and(|o| o != id) { continue; }
                 if let Some(dev) = &mut state.devices[id] {
                     if let Some(pair) = dev.take_pending_chd_sync() {
                         v.push(pair);
@@ -656,6 +659,7 @@ impl Wd33c93a {
     #[cfg(not(feature = "chd"))]
     pub fn sync_chd_disks(
         &self,
+        _only: Option<usize>,
         _progress: &mut dyn FnMut(usize, usize, f32),
         _cancel: &dyn Fn() -> bool,
     ) -> std::io::Result<usize> {

--- a/third_party/block-0.1.6/Cargo.toml
+++ b/third_party/block-0.1.6/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "block"
+version = "0.1.6"
+authors = ["Steven Sheldon"]
+
+description = "Rust interface for Apple's C language extension of blocks."
+keywords = ["blocks", "osx", "ios", "objective-c"]
+readme = "README.md"
+repository = "http://github.com/SSheldon/rust-block"
+documentation = "http://ssheldon.github.io/rust-objc/block/"
+license = "MIT"
+
+exclude = [
+  ".gitignore",
+  ".travis.yml",
+  "travis_install.sh",
+  "travis_test.sh",
+  "tests-ios/**",
+]
+

--- a/third_party/block-0.1.6/README.md
+++ b/third_party/block-0.1.6/README.md
@@ -1,0 +1,42 @@
+Rust interface for Apple's C language extension of blocks.
+
+For more information on the specifics of the block implementation, see
+Clang's documentation: http://clang.llvm.org/docs/Block-ABI-Apple.html
+
+## Invoking blocks
+
+The `Block` struct is used for invoking blocks from Objective-C. For example,
+consider this Objective-C function:
+
+``` objc
+int32_t sum(int32_t (^block)(int32_t, int32_t)) {
+    return block(5, 8);
+}
+```
+
+We could write it in Rust as the following:
+
+``` rust
+unsafe fn sum(block: &Block<(i32, i32), i32>) -> i32 {
+    block.call((5, 8))
+}
+```
+
+Note the extra parentheses in the `call` method, since the arguments must be
+passed as a tuple.
+
+## Creating blocks
+
+Creating a block to pass to Objective-C can be done with the `ConcreteBlock`
+struct. For example, to create a block that adds two `i32`s, we could write:
+
+``` rust
+let block = ConcreteBlock::new(|a: i32, b: i32| a + b);
+let block = block.copy();
+assert!(unsafe { block.call((5, 8)) } == 13);
+```
+
+It is important to copy your block to the heap (with the `copy` method) before
+passing it to Objective-C; this is because our `ConcreteBlock` is only meant
+to be copied once, and we can enforce this in Rust, but if Objective-C code
+were to copy it twice we could have a double free.

--- a/third_party/block-0.1.6/src/lib.rs
+++ b/third_party/block-0.1.6/src/lib.rs
@@ -1,0 +1,400 @@
+/*!
+A Rust interface for Objective-C blocks.
+
+For more information on the specifics of the block implementation, see
+Clang's documentation: http://clang.llvm.org/docs/Block-ABI-Apple.html
+
+# Invoking blocks
+
+The `Block` struct is used for invoking blocks from Objective-C. For example,
+consider this Objective-C function:
+
+``` objc
+int32_t sum(int32_t (^block)(int32_t, int32_t)) {
+    return block(5, 8);
+}
+```
+
+We could write it in Rust as the following:
+
+```
+# use block::Block;
+unsafe fn sum(block: &Block<(i32, i32), i32>) -> i32 {
+    block.call((5, 8))
+}
+```
+
+Note the extra parentheses in the `call` method, since the arguments must be
+passed as a tuple.
+
+# Creating blocks
+
+Creating a block to pass to Objective-C can be done with the `ConcreteBlock`
+struct. For example, to create a block that adds two `i32`s, we could write:
+
+```
+# use block::ConcreteBlock;
+let block = ConcreteBlock::new(|a: i32, b: i32| a + b);
+let block = block.copy();
+assert!(unsafe { block.call((5, 8)) } == 13);
+```
+
+It is important to copy your block to the heap (with the `copy` method) before
+passing it to Objective-C; this is because our `ConcreteBlock` is only meant
+to be copied once, and we can enforce this in Rust, but if Objective-C code
+were to copy it twice we could have a double free.
+*/
+
+#![allow(missing_abi)]
+
+#[cfg(test)]
+mod test_utils;
+
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::os::raw::{c_int, c_ulong, c_void};
+use std::ptr;
+
+// Opaque, inhabited: a static of an uninhabited type is a future hard error (rust#74840).
+#[repr(C)]
+struct Class { _priv: [*mut c_void; 32] }
+
+#[cfg_attr(any(target_os = "macos", target_os = "ios"),
+           link(name = "System", kind = "dylib"))]
+#[cfg_attr(not(any(target_os = "macos", target_os = "ios")),
+           link(name = "BlocksRuntime", kind = "dylib"))]
+extern {
+    static _NSConcreteStackBlock: Class;
+
+    fn _Block_copy(block: *const c_void) -> *mut c_void;
+    fn _Block_release(block: *const c_void);
+}
+
+/// Types that may be used as the arguments to an Objective-C block.
+pub trait BlockArguments: Sized {
+    /// Calls the given `Block` with self as the arguments.
+    ///
+    /// Unsafe because `block` must point to a valid `Block` and this invokes
+    /// foreign code whose safety the compiler cannot verify.
+    unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R;
+}
+
+macro_rules! block_args_impl {
+    ($($a:ident : $t:ident),*) => (
+        impl<$($t),*> BlockArguments for ($($t,)*) {
+            unsafe fn call_block<R>(self, block: *mut Block<Self, R>) -> R {
+                let invoke: unsafe extern fn(*mut Block<Self, R> $(, $t)*) -> R = {
+                    let base = block as *mut BlockBase<Self, R>;
+                    mem::transmute((*base).invoke)
+                };
+                let ($($a,)*) = self;
+                invoke(block $(, $a)*)
+            }
+        }
+    );
+}
+
+block_args_impl!();
+block_args_impl!(a: A);
+block_args_impl!(a: A, b: B);
+block_args_impl!(a: A, b: B, c: C);
+block_args_impl!(a: A, b: B, c: C, d: D);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
+block_args_impl!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L);
+
+#[repr(C)]
+struct BlockBase<A, R> {
+    isa: *const Class,
+    flags: c_int,
+    _reserved: c_int,
+    invoke: unsafe extern fn(*mut Block<A, R>, ...) -> R,
+}
+
+/// An Objective-C block that takes arguments of `A` when called and
+/// returns a value of `R`.
+#[repr(C)]
+pub struct Block<A, R> {
+    _base: PhantomData<BlockBase<A, R>>,
+}
+
+impl<A: BlockArguments, R> Block<A, R> where A: BlockArguments {
+    /// Call self with the given arguments.
+    ///
+    /// Unsafe because this invokes foreign code that the caller must verify
+    /// doesn't violate any of Rust's safety rules. For example, if this block
+    /// is shared with multiple references, the caller must ensure that calling
+    /// it will not cause a data race.
+    pub unsafe fn call(&self, args: A) -> R {
+        args.call_block(self as *const _ as *mut _)
+    }
+}
+
+/// A reference-counted Objective-C block.
+pub struct RcBlock<A, R> {
+    ptr: *mut Block<A, R>,
+}
+
+impl<A, R> RcBlock<A, R> {
+    /// Construct an `RcBlock` for the given block without copying it.
+    /// The caller must ensure the block has a +1 reference count.
+    ///
+    /// Unsafe because `ptr` must point to a valid `Block` and must have a +1
+    /// reference count or it will be overreleased when the `RcBlock` is
+    /// dropped.
+    pub unsafe fn new(ptr: *mut Block<A, R>) -> Self {
+        RcBlock { ptr: ptr }
+    }
+
+    /// Constructs an `RcBlock` by copying the given block.
+    ///
+    /// Unsafe because `ptr` must point to a valid `Block`.
+    pub unsafe fn copy(ptr: *mut Block<A, R>) -> Self {
+        let ptr = _Block_copy(ptr as *const c_void) as *mut Block<A, R>;
+        RcBlock { ptr: ptr }
+    }
+}
+
+impl<A, R> Clone for RcBlock<A, R> {
+    fn clone(&self) -> RcBlock<A, R> {
+        unsafe {
+            RcBlock::copy(self.ptr)
+        }
+    }
+}
+
+impl<A, R> Deref for RcBlock<A, R> {
+    type Target = Block<A, R>;
+
+    fn deref(&self) -> &Block<A, R> {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<A, R> Drop for RcBlock<A, R> {
+    fn drop(&mut self) {
+        unsafe {
+            _Block_release(self.ptr as *const c_void);
+        }
+    }
+}
+
+/// Types that may be converted into a `ConcreteBlock`.
+pub trait IntoConcreteBlock<A>: Sized where A: BlockArguments {
+    /// The return type of the resulting `ConcreteBlock`.
+    type Ret;
+
+    /// Consumes self to create a `ConcreteBlock`.
+    fn into_concrete_block(self) -> ConcreteBlock<A, Self::Ret, Self>;
+}
+
+macro_rules! concrete_block_impl {
+    ($f:ident) => (
+        concrete_block_impl!($f,);
+    );
+    ($f:ident, $($a:ident : $t:ident),*) => (
+        impl<$($t,)* R, X> IntoConcreteBlock<($($t,)*)> for X
+                where X: Fn($($t,)*) -> R {
+            type Ret = R;
+
+            fn into_concrete_block(self) -> ConcreteBlock<($($t,)*), R, X> {
+                unsafe extern fn $f<$($t,)* R, X>(
+                        block_ptr: *mut ConcreteBlock<($($t,)*), R, X>
+                        $(, $a: $t)*) -> R
+                        where X: Fn($($t,)*) -> R {
+                    let block = &*block_ptr;
+                    (block.closure)($($a),*)
+                }
+
+                let f: unsafe extern fn(*mut ConcreteBlock<($($t,)*), R, X> $(, $a: $t)*) -> R = $f;
+                unsafe {
+                    ConcreteBlock::with_invoke(mem::transmute(f), self)
+                }
+            }
+        }
+    );
+}
+
+concrete_block_impl!(concrete_block_invoke_args0);
+concrete_block_impl!(concrete_block_invoke_args1, a: A);
+concrete_block_impl!(concrete_block_invoke_args2, a: A, b: B);
+concrete_block_impl!(concrete_block_invoke_args3, a: A, b: B, c: C);
+concrete_block_impl!(concrete_block_invoke_args4, a: A, b: B, c: C, d: D);
+concrete_block_impl!(concrete_block_invoke_args5, a: A, b: B, c: C, d: D, e: E);
+concrete_block_impl!(concrete_block_invoke_args6, a: A, b: B, c: C, d: D, e: E, f: F);
+concrete_block_impl!(concrete_block_invoke_args7, a: A, b: B, c: C, d: D, e: E, f: F, g: G);
+concrete_block_impl!(concrete_block_invoke_args8, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
+concrete_block_impl!(concrete_block_invoke_args9, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
+concrete_block_impl!(concrete_block_invoke_args10, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
+concrete_block_impl!(concrete_block_invoke_args11, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
+concrete_block_impl!(concrete_block_invoke_args12, a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L);
+
+/// An Objective-C block whose size is known at compile time and may be
+/// constructed on the stack.
+#[repr(C)]
+pub struct ConcreteBlock<A, R, F> {
+    base: BlockBase<A, R>,
+    descriptor: Box<BlockDescriptor<ConcreteBlock<A, R, F>>>,
+    closure: F,
+}
+
+impl<A, R, F> ConcreteBlock<A, R, F>
+        where A: BlockArguments, F: IntoConcreteBlock<A, Ret=R> {
+    /// Constructs a `ConcreteBlock` with the given closure.
+    /// When the block is called, it will return the value that results from
+    /// calling the closure.
+    pub fn new(closure: F) -> Self {
+        closure.into_concrete_block()
+    }
+}
+
+impl<A, R, F> ConcreteBlock<A, R, F> {
+    /// Constructs a `ConcreteBlock` with the given invoke function and closure.
+    /// Unsafe because the caller must ensure the invoke function takes the
+    /// correct arguments.
+    unsafe fn with_invoke(invoke: unsafe extern fn(*mut Self, ...) -> R,
+            closure: F) -> Self {
+        ConcreteBlock {
+            base: BlockBase {
+                isa: &_NSConcreteStackBlock,
+                // 1 << 25 = BLOCK_HAS_COPY_DISPOSE
+                flags: 1 << 25,
+                _reserved: 0,
+                invoke: mem::transmute(invoke),
+            },
+            descriptor: Box::new(BlockDescriptor::new()),
+            closure: closure,
+        }
+    }
+}
+
+impl<A, R, F> ConcreteBlock<A, R, F> where F: 'static {
+    /// Copy self onto the heap as an `RcBlock`.
+    pub fn copy(self) -> RcBlock<A, R> {
+        unsafe {
+            let mut block = self;
+            let copied = RcBlock::copy(&mut *block);
+            // At this point, our copy helper has been run so the block will
+            // be moved to the heap and we can forget the original block
+            // because the heap block will drop in our dispose helper.
+            mem::forget(block);
+            copied
+        }
+    }
+}
+
+impl<A, R, F> Clone for ConcreteBlock<A, R, F> where F: Clone {
+    fn clone(&self) -> Self {
+        unsafe {
+            ConcreteBlock::with_invoke(mem::transmute(self.base.invoke),
+                self.closure.clone())
+        }
+    }
+}
+
+impl<A, R, F> Deref for ConcreteBlock<A, R, F> {
+    type Target = Block<A, R>;
+
+    fn deref(&self) -> &Block<A, R> {
+        unsafe { &*(&self.base as *const _ as *const Block<A, R>) }
+    }
+}
+
+impl<A, R, F> DerefMut for ConcreteBlock<A, R, F> {
+    fn deref_mut(&mut self) -> &mut Block<A, R> {
+        unsafe { &mut *(&mut self.base as *mut _ as *mut Block<A, R>) }
+    }
+}
+
+unsafe extern fn block_context_dispose<B>(block: &mut B) {
+    // Read the block onto the stack and let it drop
+    ptr::read(block);
+}
+
+unsafe extern fn block_context_copy<B>(_dst: &mut B, _src: &B) {
+    // The runtime memmoves the src block into the dst block, nothing to do
+}
+
+#[repr(C)]
+struct BlockDescriptor<B> {
+    _reserved: c_ulong,
+    block_size: c_ulong,
+    copy_helper: unsafe extern fn(&mut B, &B),
+    dispose_helper: unsafe extern fn(&mut B),
+}
+
+impl<B> BlockDescriptor<B> {
+    fn new() -> BlockDescriptor<B> {
+        BlockDescriptor {
+            _reserved: 0,
+            block_size: mem::size_of::<B>() as c_ulong,
+            copy_helper: block_context_copy::<B>,
+            dispose_helper: block_context_dispose::<B>,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_utils::*;
+    use super::{ConcreteBlock, RcBlock};
+
+    #[test]
+    fn test_call_block() {
+        let block = get_int_block_with(13);
+        unsafe {
+            assert!(block.call(()) == 13);
+        }
+    }
+
+    #[test]
+    fn test_call_block_args() {
+        let block = get_add_block_with(13);
+        unsafe {
+            assert!(block.call((2,)) == 15);
+        }
+    }
+
+    #[test]
+    fn test_create_block() {
+        let block = ConcreteBlock::new(|| 13);
+        let result = invoke_int_block(&block);
+        assert!(result == 13);
+    }
+
+    #[test]
+    fn test_create_block_args() {
+        let block = ConcreteBlock::new(|a: i32| a + 5);
+        let result = invoke_add_block(&block, 6);
+        assert!(result == 11);
+    }
+
+    #[test]
+    fn test_concrete_block_copy() {
+        let s = "Hello!".to_string();
+        let expected_len = s.len() as i32;
+        let block = ConcreteBlock::new(move || s.len() as i32);
+        assert!(invoke_int_block(&block) == expected_len);
+
+        let copied = block.copy();
+        assert!(invoke_int_block(&copied) == expected_len);
+    }
+
+    #[test]
+    fn test_concrete_block_stack_copy() {
+        fn make_block() -> RcBlock<(), i32> {
+            let x = 7;
+            let block = ConcreteBlock::new(move || x);
+            block.copy()
+        }
+
+        let block = make_block();
+        assert!(invoke_int_block(&block) == 7);
+    }
+}

--- a/third_party/block-0.1.6/src/test_utils.rs
+++ b/third_party/block-0.1.6/src/test_utils.rs
@@ -1,0 +1,31 @@
+extern crate objc_test_utils;
+
+use {Block, RcBlock};
+
+pub fn get_int_block_with(i: i32) -> RcBlock<(), i32> {
+    unsafe {
+        let ptr = objc_test_utils::get_int_block_with(i);
+        RcBlock::new(ptr as *mut _)
+    }
+}
+
+pub fn get_add_block_with(i: i32) -> RcBlock<(i32,), i32> {
+    unsafe {
+        let ptr = objc_test_utils::get_add_block_with(i);
+        RcBlock::new(ptr as *mut _)
+    }
+}
+
+pub fn invoke_int_block(block: &Block<(), i32>) -> i32 {
+    let ptr = block as *const _;
+    unsafe {
+        objc_test_utils::invoke_int_block(ptr as *mut _)
+    }
+}
+
+pub fn invoke_add_block(block: &Block<(i32,), i32>, a: i32) -> i32 {
+    let ptr = block as *const _;
+    unsafe {
+        objc_test_utils::invoke_add_block(ptr as *mut _, a)
+    }
+}


### PR DESCRIPTION
Dependency hygiene
- glow: iris pinned 0.13 while eframe pulled 0.17, so both compiled into iris-gui. Bumped iris to 0.17 and adapted the call sites -- tex_image_2d takes PixelUnpackData now, and PixelUnpackData/PixelPackData::Slice wrap an Option as of glow 0.14.
- spin: iris asked for 0.12 while flume (via nokhwa) pins ^0.9.8. Moved to 0.9 to unify; usage is two spin::Mutex imports with an identical API.
- block 0.1.6 declares a static of an uninhabited type, a future hard error (rust#74840). Its final release was 2016, so upstream will never fix it -- vendored under third_party/ with Class made opaque-but-inhabited, the same shape its maintained successor block2 uses. Also clears the future-incompatibility report.
- eframe/egui 0.35 -> 0.36.1 (no source changes; still resolves winit 0.30.13, so the vendored App Store SkyLight patch and the glow 0.17 dedupe both still hold), rtrb 0.3 -> 0.4, plus cargo update (cpal, pcap, ureq, icu_*, ...). Deliberately held back: glow 0.18 and spin 0.12 would re-split the graph, region 4.0 duplicates against cranelift-jit's ^3, libc 1.0 is a pre-release.

iris-gui
- Browse opened the OS default folder rather than the disk's own. Two causes: scsi_menu's pick_disk/pick_iso never called set_directory at all, and the Disks tab's "Attach..." seeded a bare relative "scsiN.raw" whose parent is "", so path_row's guard fell through. Both now seed from the current path and fall back to the managed disks dir.
- Create-disk used File::create, which truncates, and pre-fills the filename with the disk already attached at that SCSI id -- so a second visit to the dialog silently erased an installed image. It now warns with the existing file's size and gates Create behind an explicit erase checkbox.
- Port forwards: added SSH (2222->22) and VNC (5901->5900; host side dodges macOS Screen Sharing, which owns 5900). Telnet 2323->23 already existed.

CI
- iris-ci chd-sync [ID|all] folds pending CHD diffs back into their bases, refusing to run while the CPU is up -- folding releases the disk backend, which would yank the drive out from under a live guest.
- iris-ci quit --sync-chd [ID|all] stops the machine and folds before exit, mirroring the GUI's flatten-on-exit ordering.
- sync_chd_disks gained an `only: Option<usize>` selector; None means all. Fold commands use a 3h client read timeout, since recompressing a base routinely outruns the 300s default.

Warning-free across 27 iris and 8 iris-gui feature combinations plus the release profile; 360 + 28 tests pass.